### PR TITLE
feat(pipeline): expanded repo-list builder (landscape ∪ .project) + runbook

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -83,44 +83,88 @@ Runs the GraphQL data collector against the expanded repo list.
 ```bash
 export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx
 
-# Full landscape scan (use expanded list for maximum coverage)
+# Full landscape scan with .project metadata (recommended)
+npx ts-node src/neo.ts \
+  --input input/cncf-expanded-repo-list.json \
+  --queries GetRepoDataExtendedInfo \
+  --dot-project \
+  --analyze \
+  --parallel
+
+# Without .project metadata (faster, skips dot_project* tables)
 npx ts-node src/neo.ts \
   --input input/cncf-expanded-repo-list.json \
   --queries GetRepoDataExtendedInfo \
   --analyze \
   --parallel
 
-# Or with maturity filter (e.g., graduated only)
+# With maturity filter (e.g., graduated only) + .project
 npx ts-node src/neo.ts \
   --input input/cncf-expanded-repo-list.json \
   --queries GetRepoDataExtendedInfo \
   --maturity graduated \
+  --dot-project \
   --analyze \
   --parallel
 
-# Or use npm alias (runs against cncf-full-landscape.json)
+# Or use npm alias (runs against cncf-full-landscape.json, no --dot-project by default)
 GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx npm start
 ```
+
+### --dot-project flag
+
+When `--dot-project` is passed, the collector additionally:
+
+1. Collects all unique GitHub orgs from the scanned repos.
+2. For each org, fetches `https://github.com/<org>/.project` via the same GraphQL
+   blob-fetch mechanism used for SECURITY.md and workflow files
+   (`object(expression: "HEAD:project.yaml") { ... on Blob { text } }`).
+3. Parses the `project.yaml` YAML and normalizes it into four DuckDB tables:
+
+| Table | Description |
+|-------|-------------|
+| `dot_project` | One row per org that has a `.project` repo — top-level fields (slug, name, current maturity, security fields, etc.) |
+| `dot_project_repositories` | One row per URL in `repositories[]` — parsed into `repo_owner`/`repo_name` |
+| `dot_project_maturity_log` | One row per `maturity_log[]` entry (phase, date, issue URL) |
+| `dot_project_audits` | One row per `audits[]` entry (date, type, URL) |
+
+Orgs without a `.project` repo (the majority — ~61/251 CNCF orgs have one as of 2026)
+are silently skipped. Handle-absence is built into the GraphQL blob-fetch: a missing
+repo returns `repository: null`; a missing file returns `projectYaml: null`.
+
+**Relationship to build-repo-list.ts:**
+`build-repo-list.ts` (Step 1) also fetches `.project` repos, but via unauthenticated
+raw HTTP (`raw.githubusercontent.com`) *pre-scan* to build the repo list. The `--dot-project`
+flag fetches them *during the scan* via GraphQL with auth, normalizes all fields (not just
+`repositories[]`), and lands them in DuckDB. They are complementary:
+- Step 1 enriches the repo list with `.project` `repositories[]`
+- Step 2 `--dot-project` captures all `.project` metadata fields in DuckDB
 
 **Output structure:**
 
 ```
 output/<input-basename>/<ISO-timestamp>/
-  database.db                              ← DuckDB (base + agg tables)
-  parquet/                                 ← Parquet files per table
+  database.db                              ← DuckDB (base + agg + dot_project* tables)
+  parquet/
+    dot_project.parquet
+    dot_project_repositories.parquet
+    dot_project_maturity_log.parquet
+    dot_project_audits.parquet
+    ...other tables...
   raw-responses.GetRepoDataExtendedInfo.jsonl  ← audit log (JSONL)
   files/                                   ← SECURITY.md, security-insights.yml
-  security-insights-attestations.csv
-  security-insights-sboms.csv
 output/<input-basename>/current -> <latest-timestamp>/   ← symlink
 ```
 
 **What requires the token:**
 - All `npm start` / `npx ts-node src/neo.ts` invocations — GitHub GraphQL API requires auth.
 - `--scan-orgs` mode (org-level repo discovery) — also requires token.
+- `--dot-project` mode — also requires token (GraphQL API).
 
 **What does NOT require a token:**
 - Steps 1, 3, 4, 5 (repo list build, graph build, export, queries).
+- `.project` YAML parsing / DuckDB normalization (the `parseDotProject` function
+  is token-free and testable with local fixtures — see "Pipeline Validation" below).
 
 ---
 
@@ -384,6 +428,48 @@ npm run build:repos -- --dry-run --no-dot-project
 │ 1       │ 'Jaeger'       │ 'jaegertracing/jaeger' │
 └─────────┴────────────────┴────────────────────────┘
 2 row(s)
+```
+
+### .project Parse Validation (No Token)
+
+The `parseDotProject` normalizer can be validated without a token using local YAML fixtures.
+The example below uses the schema example at `~/gh/f/cncf/automation/utilities/dot-project/example/project.yaml`
+as a parse target, then queries the resulting DuckDB tables:
+
+```bash
+# Run the standalone .project parse test (no network, no token)
+npx ts-node scripts/test-dot-project-parse.ts
+
+# Or validate the normalizer unit test
+npx ts-node -e "
+const { parseDotProject } = require('./src/normalizers/DotProjectNormalizer');
+const fs = require('fs');
+const yaml = fs.readFileSync('./input/test-dot-project-argoproj.yaml', 'utf-8');
+const result = parseDotProject('argoproj', yaml, 'https://github.com/argoproj/.project/blob/HEAD/project.yaml');
+console.log(JSON.stringify(result, null, 2));
+"
+```
+
+For an end-to-end test against a real `.project` repo without a GraphQL token,
+use the unauthenticated raw fetch (same as `build-repo-list.ts` Step 1):
+
+```bash
+# Fetch argoproj/.project/project.yaml via raw.githubusercontent.com (no auth)
+curl -s https://raw.githubusercontent.com/argoproj/.project/main/project.yaml | \
+  npx ts-node -e "
+const { parseDotProject } = require('./src/normalizers/DotProjectNormalizer');
+const fs = require('fs');
+process.stdin.resume();
+let data = '';
+process.stdin.on('data', d => data += d);
+process.stdin.on('end', () => {
+  const result = parseDotProject('argoproj', data, 'test');
+  console.log(JSON.stringify(result?.dot_project[0], null, 2));
+  console.log('repositories:', result?.dot_project_repositories.length);
+  console.log('maturity entries:', result?.dot_project_maturity_log.length);
+  console.log('audits:', result?.dot_project_audits.length);
+});
+"
 ```
 
 ---

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -22,7 +22,9 @@ This is an internal engineering reference, not a CNCF report.
 Builds `input/cncf-expanded-repo-list.json` by UNION-ing:
 - **(a)** CNCF landscape repos from `https://landscape.cncf.io/data/full.json` (`.items[]`)
 - **(b)** `.project` `repositories[]` for each CNCF project (fetched from
-  `https://raw.githubusercontent.com/<org>/.project/main/project.yaml`)
+  `https://raw.githubusercontent.com/<org>/.project/HEAD/project.yaml` — the `HEAD`
+  symbolic ref resolves to the repo's default branch, so no main-vs-master guessing;
+  this matches the GraphQL `HEAD:project.yaml` expression used by `--dot-project`)
 
 Each entry carries a `source` field: `"landscape"`, `"dot-project"`, or `"both"`.
 Deduplication is on `owner/name` (case-insensitive).
@@ -115,22 +117,38 @@ GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx npm start
 
 When `--dot-project` is passed, the collector additionally:
 
-1. Collects all unique GitHub orgs from the scanned repos.
+1. Builds an ordered, de-duplicated org list to probe:
+   - **canonical orgs first** — the org of each project's *primary* repo (the
+     canonical `.project` location per the schema), so a project whose non-primary
+     repos live under a different/legacy org is not missed;
+   - then all remaining repo-owner orgs (fallback coverage for multi-org projects).
 2. For each org, fetches `https://github.com/<org>/.project` via the same GraphQL
    blob-fetch mechanism used for SECURITY.md and workflow files
-   (`object(expression: "HEAD:project.yaml") { ... on Blob { text } }`).
-3. Parses the `project.yaml` YAML and normalizes it into four DuckDB tables:
+   (`object(expression: "HEAD:project.yaml") { ... on Blob { text } }`), also
+   pulling `maintainers.yaml` and the default-branch commit SHA (for a permalink
+   `source_url`). Requests run in batches of 8 with a 600 ms inter-batch delay,
+   matching `build-repo-list.ts`.
+3. Parses `project.yaml` (and `maintainers.yaml`) and normalizes into five DuckDB tables:
 
-| Table | Description |
-|-------|-------------|
-| `dot_project` | One row per org that has a `.project` repo — top-level fields (slug, name, current maturity, security fields, etc.) |
-| `dot_project_repositories` | One row per URL in `repositories[]` — parsed into `repo_owner`/`repo_name` |
-| `dot_project_maturity_log` | One row per `maturity_log[]` entry (phase, date, issue URL) |
-| `dot_project_audits` | One row per `audits[]` entry (date, type, URL) |
+| Table | Key | Description |
+|-------|-----|-------------|
+| `dot_project` | PK `org` | One row per org with a `.project` repo — top-level fields (slug, name, current maturity, security fields, landscape, etc.) |
+| `dot_project_repositories` | PK `(org, position)` | One row per URL in `repositories[]` — parsed into `repo_owner`/`repo_name` (null for relative/non-github URLs) |
+| `dot_project_maturity_log` | PK `(org, position)` | One row per `maturity_log[]` entry (phase, `date` as TIMESTAMP, issue URL) |
+| `dot_project_audits` | PK `(org, position)` | One row per `audits[]` entry (`date` as TIMESTAMP, type, URL) |
+| `dot_project_maintainers` | — | One row per maintainer member from `maintainers.yaml` (org, project_id, team, member) |
 
 Orgs without a `.project` repo (the majority — ~61/251 CNCF orgs have one as of 2026)
 are silently skipped. Handle-absence is built into the GraphQL blob-fetch: a missing
 repo returns `repository: null`; a missing file returns `projectYaml: null`.
+
+**Robustness:** `.project` files are hand-edited and frequently violate the schema
+(a scalar where a list is expected, non-string entries, wrong types). The parser
+(`parseDotProject`) is contractually **no-throw**: it coerces scalar→array, skips
+non-string/non-object entries with a warning, and validates `project_lead` (a
+numeric lead is dropped as NULL, never coerced to a bogus `"42"`). A malformed
+`.project` for one org logs + skips that org and the scan continues. Tolerated
+schema violations are summarized as warning counts at the end of the run.
 
 **Relationship to build-repo-list.ts:**
 `build-repo-list.ts` (Step 1) also fetches `.project` repos, but via unauthenticated
@@ -150,6 +168,7 @@ output/<input-basename>/<ISO-timestamp>/
     dot_project_repositories.parquet
     dot_project_maturity_log.parquet
     dot_project_audits.parquet
+    dot_project_maintainers.parquet
     ...other tables...
   raw-responses.GetRepoDataExtendedInfo.jsonl  ← audit log (JSONL)
   files/                                   ← SECURITY.md, security-insights.yml

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,426 @@
+# Supply-Chain Security Collector — Internal Runbook
+
+**Purpose:** Reproducible commands for the full data pipeline: repo-list refresh → collect → graph → export → query.
+This is an internal engineering reference, not a CNCF report.
+
+---
+
+## Pipeline Overview
+
+```
+[1] build:repos      → input/cncf-expanded-repo-list.json   (no token needed)
+[2] npm start        → output/<name>/<ts>/database.db        (GitHub token required)
+[3] npm run graph    → output/<name>/<ts>/graph.lbug          (no token needed)
+[4] export parquet   → bucket/<name>/<ts>/parquet/            (bucket URL needed)
+[5] insight queries  → npm run graph:query / DuckDB SQL       (no token needed)
+```
+
+---
+
+## Step 1 — Refresh the Repo List
+
+Builds `input/cncf-expanded-repo-list.json` by UNION-ing:
+- **(a)** CNCF landscape repos from `https://landscape.cncf.io/data/full.json` (`.items[]`)
+- **(b)** `.project` `repositories[]` for each CNCF project (fetched from
+  `https://raw.githubusercontent.com/<org>/.project/main/project.yaml`)
+
+Each entry carries a `source` field: `"landscape"`, `"dot-project"`, or `"both"`.
+Deduplication is on `owner/name` (case-insensitive).
+
+### Run
+
+```bash
+# Full build: landscape + .project (recommended)
+npm run build:repos
+
+# Landscape only (no network calls to .project repos)
+npm run build:repos -- --no-dot-project
+
+# Custom output path
+npm run build:repos -- --output input/my-custom-list.json
+
+# Dry-run: print counts, don't write files
+npm run build:repos -- --dry-run
+
+# Verbose: log each .project repo discovered
+npm run build:repos -- --verbose
+```
+
+### Optional: GitHub token to avoid rate-limiting
+
+Without a token, all fetches use unauthenticated `raw.githubusercontent.com` GETs
+(fine for public repos; degraded if GitHub starts rate-limiting unauthenticated GETs).
+
+```bash
+GITHUB_TOKEN=ghp_xxx npm run build:repos
+# or
+GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx npm run build:repos
+```
+
+### What this replaces
+
+Previously, `npm run fetch:landscape` fetched `landscape.yml` from GitHub raw and produced
+`input/cncf-full-landscape.json` (landscape repos only). The new `build:repos` script
+supersedes it and adds `.project` enrichment.
+
+> **Landscape endpoint note:**
+> `https://landscape.cncf.io/data/items.json` returns HTML (landscape2 SPA shell) — DEAD.
+> `https://landscape.cncf.io/data/full.json` returns `application/json` with `.items[]` — USE THIS.
+> `build-repo-list.ts` uses `full.json`. The legacy `fetch-cncf-landscape.ts` uses
+> `raw.githubusercontent.com/.../landscape.yml` (also fine — YAML source is still live).
+
+### Idempotency
+
+Running `build:repos` multiple times produces the same output given the same upstream state.
+The script is stateless — no local cache is written.
+
+---
+
+## Step 2 — Full Scan (GitHub token required)
+
+Runs the GraphQL data collector against the expanded repo list.
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx
+
+# Full landscape scan (use expanded list for maximum coverage)
+npx ts-node src/neo.ts \
+  --input input/cncf-expanded-repo-list.json \
+  --queries GetRepoDataExtendedInfo \
+  --analyze \
+  --parallel
+
+# Or with maturity filter (e.g., graduated only)
+npx ts-node src/neo.ts \
+  --input input/cncf-expanded-repo-list.json \
+  --queries GetRepoDataExtendedInfo \
+  --maturity graduated \
+  --analyze \
+  --parallel
+
+# Or use npm alias (runs against cncf-full-landscape.json)
+GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx npm start
+```
+
+**Output structure:**
+
+```
+output/<input-basename>/<ISO-timestamp>/
+  database.db                              ← DuckDB (base + agg tables)
+  parquet/                                 ← Parquet files per table
+  raw-responses.GetRepoDataExtendedInfo.jsonl  ← audit log (JSONL)
+  files/                                   ← SECURITY.md, security-insights.yml
+  security-insights-attestations.csv
+  security-insights-sboms.csv
+output/<input-basename>/current -> <latest-timestamp>/   ← symlink
+```
+
+**What requires the token:**
+- All `npm start` / `npx ts-node src/neo.ts` invocations — GitHub GraphQL API requires auth.
+- `--scan-orgs` mode (org-level repo discovery) — also requires token.
+
+**What does NOT require a token:**
+- Steps 1, 3, 4, 5 (repo list build, graph build, export, queries).
+
+---
+
+## Step 3 — Build the Graph (LadybugDB)
+
+Reads the DuckDB output from Step 2 and builds a LadybugDB property graph
+for Cypher-based supply chain security queries.
+
+```bash
+# Build graph from the latest collect run (using the 'current' symlink)
+npm run graph -- --database output/cncf-expanded-repo-list/current/database.db
+
+# Or specify explicit timestamp directory
+npm run graph -- --database output/cncf-expanded-repo-list/2026-07-17T12-00-00/database.db
+
+# Optional: custom output graph path
+npm run graph -- \
+  --database output/cncf-expanded-repo-list/current/database.db \
+  --output output/cncf-expanded-repo-list/current/graph.lbug
+```
+
+**Output:** `graph.lbug` directory alongside the `database.db`.
+
+**List available Cypher queries:**
+
+```bash
+npm run graph:list
+```
+
+---
+
+## Step 4 — Export DuckDB + Parquet to Bucket
+
+> Replace `BUCKET_URL` with your actual bucket path (e.g. `s3://my-bucket/supply-chain/`
+> or `gs://my-bucket/supply-chain/`).
+
+### Export Parquet files
+
+```bash
+BUCKET_URL="s3://my-bucket/supply-chain"
+RUN_DIR="output/cncf-expanded-repo-list/current"
+
+# Copy the full run directory (DuckDB + Parquet + audit log)
+aws s3 cp --recursive "${RUN_DIR}/parquet/" "${BUCKET_URL}/parquet/"
+aws s3 cp "${RUN_DIR}/database.db" "${BUCKET_URL}/database.db"
+aws s3 cp "${RUN_DIR}/raw-responses.GetRepoDataExtendedInfo.jsonl" \
+          "${BUCKET_URL}/raw-responses.GetRepoDataExtendedInfo.jsonl"
+```
+
+### Export with DuckDB COPY (direct from database)
+
+```bash
+# Example: export a specific table to Parquet in the bucket
+duckdb output/cncf-expanded-repo-list/current/database.db \
+  "COPY base_repositories TO '${BUCKET_URL}/base_repositories.parquet' (FORMAT PARQUET)"
+```
+
+### Read Parquet from bucket in DuckDB (for remote analysis)
+
+```bash
+duckdb :memory: \
+  "SELECT * FROM read_parquet('${BUCKET_URL}/parquet/base_repositories.parquet') LIMIT 10"
+```
+
+---
+
+## Step 5 — Run Insight Queries
+
+### Cypher queries (graph)
+
+Run against the LadybugDB graph built in Step 3.
+
+```bash
+GRAPH_PATH="output/cncf-expanded-repo-list/current/graph.lbug"
+
+# List all built-in queries
+npm run graph:list
+
+# Run a built-in query
+npm run graph:query -- --graph "${GRAPH_PATH}" --name graduated-no-signing
+npm run graph:query -- --graph "${GRAPH_PATH}" --name project-tool-summary
+npm run graph:query -- --graph "${GRAPH_PATH}" --name tool-cooccurrence
+npm run graph:query -- --graph "${GRAPH_PATH}" --name maturity-tool-adoption
+npm run graph:query -- --graph "${GRAPH_PATH}" --name full-pipeline
+npm run graph:query -- --graph "${GRAPH_PATH}" --name unmonitored-graduated
+
+# Run an ad-hoc Cypher query
+npm run graph:query -- \
+  --graph "${GRAPH_PATH}" \
+  --cypher "MATCH (p:CNCFProject)<-[:BELONGS_TO]-(r:Repository) RETURN p.display_name, count(r) AS repos ORDER BY repos DESC LIMIT 20"
+
+# Run a query from a .cypher file
+npm run graph:query -- --graph "${GRAPH_PATH}" --file cypher/maturity-tool-adoption.cypher
+```
+
+### SQL queries (DuckDB)
+
+```bash
+DB_PATH="output/cncf-expanded-repo-list/current/database.db"
+
+# List tables
+duckdb "${DB_PATH}" ".tables"
+
+# Basic provenance check
+duckdb "${DB_PATH}" \
+  "SELECT maturity, count(*) AS projects, sum(repo_count) AS repos
+   FROM agg_project_summary GROUP BY maturity ORDER BY maturity"
+
+# Workflow tool usage by project
+duckdb "${DB_PATH}" \
+  "SELECT project_name, tool_name, category
+   FROM agg_workflow_tools ORDER BY project_name, category"
+```
+
+---
+
+## Milestone-1 Target Queries
+
+These are the Milestone-1 analytical questions. Implement as Cypher or SQL against
+the graph/DuckDB built above.
+
+### Q1 — License "rug pull" impact
+
+> *Which CNCF projects changed their license? How many downstream dependents
+> (by release asset count or workflow SBOM references) are potentially impacted?*
+
+**Approach:** The current schema captures `license` per project from the landscape.
+A rug-pull signal requires a historical diff (not yet implemented). For now, identify
+projects whose landscape-declared license differs from what the collector read from
+their GitHub repo's `license_info.spdx_id`:
+
+```sql
+-- DuckDB: projects where landscape-declared license differs from GitHub-detected license
+SELECT
+    r.project_name,
+    r.maturity,
+    r.landscape_license,
+    r.github_license
+FROM base_repositories r
+WHERE r.landscape_license IS NOT NULL
+  AND r.github_license IS NOT NULL
+  AND r.landscape_license != r.github_license
+ORDER BY r.maturity, r.project_name;
+```
+
+```cypher
+// Cypher: graduated projects with a mismatched or missing license
+MATCH (p:CNCFProject {maturity: 'graduated'})<-[:BELONGS_TO]-(r:Repository)
+WHERE r.landscape_license IS NOT NULL
+  AND (r.github_license IS NULL OR r.landscape_license <> r.github_license)
+RETURN p.display_name, r.nameWithOwner, r.landscape_license, r.github_license
+ORDER BY p.display_name
+```
+
+### Q2 — CVE impact across the CNCF ecosystem
+
+> *Which CVEs (from security-insights.yml / SBOM attestations) affect the most
+> CNCF projects? What is the blast radius?*
+
+**Approach:** `security-insights.yml` files (collected in `files/`) and SBOM assets
+from releases. The collector writes `security-insights-sboms.csv` and
+`security-insights-attestations.csv`. Query across projects:
+
+```sql
+-- DuckDB: release assets that look like SBOM or attestation files
+SELECT
+    r.project_name,
+    r.nameWithOwner,
+    ra.name AS asset_name,
+    ra.download_count
+FROM base_release_assets ra
+JOIN base_repositories r ON r.id = ra.repository_id
+WHERE lower(ra.name) LIKE '%sbom%'
+   OR lower(ra.name) LIKE '%.intoto.jsonl'
+   OR lower(ra.name) LIKE '%.att'
+ORDER BY r.project_name, ra.name;
+```
+
+```cypher
+// Cypher (graph Q15): landscape question — projects with SBOM assets but no signing tool
+MATCH (p:CNCFProject)<-[:BELONGS_TO]-(r:Repository)-[:HAS_RELEASE]->(rel:Release)-[:HAS_ASSET]->(a:ReleaseAsset)
+WHERE a.name CONTAINS 'sbom'
+  AND NOT EXISTS {
+      MATCH (r)-[:HAS_WORKFLOW]->(:Workflow)-[:USES_TOOL]->(t:Tool)
+      WHERE t.tool_name IN ['cosign', 'sigstore', 'notation']
+  }
+RETURN p.display_name, p.maturity, r.nameWithOwner,
+       count(DISTINCT rel) AS releases_with_sbom
+ORDER BY p.maturity, p.display_name
+```
+
+### Q3 — Landscape graph question #15
+
+> *Which graduated projects publish SBOM assets in releases but have no signing
+> tool detected in any CI workflow?*
+
+```cypher
+MATCH (p:CNCFProject {maturity: 'graduated'})<-[:BELONGS_TO]-(r:Repository)
+      -[:HAS_RELEASE]->(rel:Release)-[:HAS_ASSET]->(a:ReleaseAsset)
+WHERE (a.name CONTAINS 'sbom' OR a.name CONTAINS '.spdx' OR a.name CONTAINS '.cyclonedx')
+  AND NOT EXISTS {
+      MATCH (r)-[:HAS_WORKFLOW]->(:Workflow)-[:USES_TOOL]->(t:Tool)
+      <-[:IN_CATEGORY]-(:ToolCategory {category_name: 'signer'})
+  }
+RETURN p.display_name, r.nameWithOwner,
+       count(DISTINCT a) AS sbom_assets,
+       count(DISTINCT rel) AS releases
+ORDER BY sbom_assets DESC
+```
+
+---
+
+## What Needs a Token vs. What Needs a Bucket
+
+| Step | Needs GitHub Token | Needs Bucket |
+|------|-------------------|--------------|
+| `npm run build:repos` | No (but helps with rate limits) | No |
+| `npm run fetch:landscape` | No | No |
+| `npm start` / `npm run test:three` | **YES** | No |
+| `npm run graph` | No | No |
+| `npm run graph:list` | No | No |
+| `npm run graph:query` | No | No |
+| Parquet export to bucket | No | **YES** — set `BUCKET_URL` |
+| Remote Parquet reads via httpfs | No | **YES** |
+| `npm run analyze` / `npm run report` | No | No |
+
+---
+
+## Pipeline Validation (Without Token)
+
+The following runs green without a GitHub token, using committed test fixtures
+in `output/test-three-projects/`:
+
+```bash
+# 1. List available Cypher queries
+npm run graph:list
+
+# 2. Build graph from committed test fixture
+npm run graph -- --database output/test-three-projects/current/database.db
+
+# 3. Run a Cypher query on the test graph
+npm run graph:query -- \
+  --graph output/test-three-projects/current/graph.lbug \
+  --name graduated-no-signing
+
+# 4. Run project-tool-summary
+npm run graph:query -- \
+  --graph output/test-three-projects/current/graph.lbug \
+  --name project-tool-summary
+
+# 5. Dry-run the repo list builder (no writes, no token)
+npm run build:repos -- --dry-run --no-dot-project
+```
+
+**Expected output for `graduated-no-signing` on test fixture:**
+```
+┌─────────┬────────────────┬────────────────────────┐
+│ (index) │ p.display_name │ r.nameWithOwner        │
+├─────────┼────────────────┼────────────────────────┤
+│ 0       │ 'Helm'         │ 'helm/helm'            │
+│ 1       │ 'Jaeger'       │ 'jaegertracing/jaeger' │
+└─────────┴────────────────┴────────────────────────┘
+2 row(s)
+```
+
+---
+
+## Troubleshooting
+
+### `items.json` returns HTML instead of JSON
+
+**Symptom:** `fetch-cncf-landscape.ts` or a custom script hits
+`https://landscape.cncf.io/data/items.json` and gets `content-type: text/html`.
+
+**Cause:** The landscape2 migration moved the data to `full.json`. The `items.json`
+URL now returns the SPA shell HTML.
+
+**Fix:** Change the URL to `https://landscape.cncf.io/data/full.json` and access
+`.items[]` instead of the top-level array. The `build-repo-list.ts` script already
+uses `full.json`.
+
+### `.project` repos return 404
+
+Most CNCF projects have not yet published a `.project` repo. The builder degrades
+gracefully — 404s are silently skipped, and the landscape data is used as-is.
+As more projects adopt `.project`, the builder will automatically pick them up.
+
+### DuckDB extension install failures
+
+Extensions (`json`, `parquet`, `fts`, `httpfs`) are auto-installed on first run.
+If you're in an air-gapped environment:
+
+```bash
+# Pre-install extensions manually
+duckdb :memory: "INSTALL json; INSTALL parquet; INSTALL fts; INSTALL httpfs"
+```
+
+### Graph build skips tables
+
+If `graph.lbug` is missing expected tables (e.g., `Tool`, `ToolCategory`), the
+collect run may not have detected any workflow tool usage. This is expected for
+projects with no GitHub Actions workflows, or workflows that use unrecognized tools.
+Check `agg_workflow_tools` in the DuckDB database.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "graph:query": "ts-node src/graph/graph-cli.ts query",
     "graph:list": "ts-node src/graph/graph-cli.ts list",
     "fetch:landscape": "ts-node scripts/fetch-cncf-landscape.ts",
+    "build:repos": "ts-node scripts/build-repo-list.ts",
     "codegen": "graphql-codegen --config codegen.ts",
     "postinstall": "npm run codegen",
     "lint": "npx eslint src/",

--- a/scripts/build-repo-list.ts
+++ b/scripts/build-repo-list.ts
@@ -1,0 +1,498 @@
+/**
+ * build-repo-list.ts
+ *
+ * Builds a reproducible, deduplicated repository list for the supply-chain-security-collector
+ * by UNION-ing two sources:
+ *
+ *   (a) CNCF landscape repos — from https://landscape.cncf.io/data/full.json (.items[])
+ *       The full.json endpoint returns real application/json. Do NOT use items.json —
+ *       that URL now returns the landscape2 SPA shell (HTML).
+ *
+ *   (b) .project repositories[] — for each CNCF project, fetches
+ *       https://raw.githubusercontent.com/<org>/.project/main/project.yaml
+ *       and adds any repos not already in the landscape. Projects without a .project
+ *       repo (404) are skipped gracefully.
+ *
+ * Each output entry carries a `source` provenance label: "landscape", "dot-project", or "both".
+ * Deduplication is on nameWithOwner (owner/name, case-insensitive).
+ *
+ * Usage:
+ *   npm run build:repos                                       # fetch live, write to input/
+ *   npm run build:repos -- --output input/my-custom.json     # custom output path
+ *   npm run build:repos -- --no-dot-project                  # landscape only (no .project fetch)
+ *   npm run build:repos -- --dry-run                         # print summary, don't write files
+ *   npm run build:repos -- --verbose                         # log per-project detail
+ *
+ * Environment (optional):
+ *   GITHUB_TOKEN or GITHUB_PERSONAL_ACCESS_TOKEN  — reduces rate-limiting on .project fetches.
+ *   Without a token, unauthenticated raw.githubusercontent.com GETs are used.
+ */
+
+import fetch from 'node-fetch';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+
+// ============================================================================
+// CLI ARGS
+// ============================================================================
+
+function parseArgs(): {
+  output: string;
+  dotProject: boolean;
+  dryRun: boolean;
+  verbose: boolean;
+} {
+  const args = process.argv.slice(2);
+  let output = path.join(__dirname, '../input/cncf-expanded-repo-list.json');
+  let dotProject = true;
+  let dryRun = false;
+  let verbose = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--output' && args[i + 1]) {
+      output = args[++i];
+    } else if (args[i] === '--no-dot-project') {
+      dotProject = false;
+    } else if (args[i] === '--dry-run') {
+      dryRun = true;
+    } else if (args[i] === '--verbose' || args[i] === '-v') {
+      verbose = true;
+    }
+  }
+
+  return { output, dotProject, dryRun, verbose };
+}
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+// Matches src/config.ts ProjectMetadata + provenance extension
+interface RepoRef {
+  owner: string;
+  name: string;
+  primary: boolean;
+  branch?: string;
+}
+
+interface ProjectMetadataWithSource {
+  project_name: string;
+  display_name?: string;
+  description?: string;
+  repos: RepoRef[];
+  maturity?: 'graduated' | 'incubating' | 'sandbox' | 'archived';
+  category?: string;
+  subcategory?: string;
+  date_accepted?: string;
+  date_incubating?: string;
+  date_graduated?: string;
+  date_archived?: string;
+  homepage_url?: string;
+  repo_url?: string;        // primary repo URL (for compatibility with existing pipeline)
+  package_manager_url?: string;
+  docker_url?: string;
+  documentation_url?: string;
+  blog_url?: string;
+  url_for_bestpractices?: string;
+  clomonitor_name?: string;
+  has_security_audits?: boolean;
+  security_audit_count?: number;
+  latest_audit_date?: string;
+  latest_audit_vendor?: string;
+  crunchbase?: string;
+  twitter?: string;
+  parent_project?: string;
+  tag_associations?: string;
+  annual_review_date?: string;
+  annual_review_url?: string;
+  license?: string;
+  default_branch?: string;
+  dev_stats_url?: string;
+  // Provenance (extension beyond base ProjectMetadata)
+  source: 'landscape' | 'dot-project' | 'both';
+  dot_project_repos?: string[];  // net-new repos added from .project
+}
+
+// landscape.cncf.io/data/full.json item shape
+// full.json uses a flat structure (no nested `extra`, no `additional_repos`).
+interface FullJsonRepository {
+  url: string;
+  primary?: boolean;
+  branch?: string;
+}
+
+interface FullJsonAudit {
+  date?: string;
+  type?: string;
+  url?: string;
+  vendor?: string;
+}
+
+interface FullJsonSummary {
+  business_use_case?: string;
+  integrations?: string;
+  personas?: string[];
+  release_rate?: string;
+  tags?: string[];
+  use_case?: string;
+}
+
+interface FullJsonItem {
+  // Core identity
+  id: string;
+  name: string;
+  category: string;
+  subcategory: string;
+  maturity?: 'graduated' | 'incubating' | 'sandbox' | 'archived';
+  // Repos
+  repositories?: FullJsonRepository[];
+  // URLs
+  homepage_url?: string;
+  website?: string;
+  crunchbase_url?: string;
+  twitter_url?: string;
+  devstats_url?: string;
+  mailing_list_url?: string;
+  slack_url?: string;
+  artwork_url?: string;
+  blog_url?: string;
+  // CNCF dates
+  accepted_at?: string;
+  incubating_at?: string;
+  graduated_at?: string;
+  archived_at?: string;
+  // Security
+  audits?: FullJsonAudit[];
+  // CLOMonitor
+  clomonitor_name?: string;
+  lfx_slug?: string;
+  // Tags
+  oss?: boolean;
+  // Summary fields
+  summary?: FullJsonSummary;
+  // Extra fields we may not need but shouldn't error on
+  [key: string]: unknown;
+}
+
+interface FullJsonResponse {
+  items?: FullJsonItem[];
+  [key: string]: unknown;
+}
+
+// .project project.yaml shape (what we need)
+interface DotProjectYaml {
+  schema_version?: string;
+  slug?: string;
+  name?: string;
+  description?: string;
+  repositories?: string[];
+  maturity_log?: Array<{ phase?: string; date?: string; issue?: string }>;
+}
+
+// ============================================================================
+// LANDSCAPE SOURCE
+// ============================================================================
+
+// IMPORTANT: Use full.json, NOT items.json.
+// items.json returns HTML (landscape2 SPA shell) — content-type: text/html.
+// full.json returns content-type: application/json with an .items[] array.
+const FULL_JSON_URL = 'https://landscape.cncf.io/data/full.json';
+
+function repoFromUrl(url: string, primary: boolean, branch?: string): RepoRef | null {
+  if (!url) return null;
+  const match = url.match(/github\.com\/([^/]+)\/([^/#? ]+)/);
+  if (!match) return null;
+  return {
+    owner: match[1],
+    name: match[2].replace(/\.git$/, ''),
+    primary,
+    branch,
+  };
+}
+
+async function fetchLandscapeProjects(): Promise<Map<string, ProjectMetadataWithSource>> {
+  console.log(`\nFetching landscape: ${FULL_JSON_URL}`);
+  const resp = await fetch(FULL_JSON_URL);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch full.json: ${resp.status} ${resp.statusText}`);
+  }
+  const contentType = resp.headers.get('content-type') || '';
+  if (contentType.includes('text/html')) {
+    throw new Error(
+      `full.json returned text/html — the URL may have changed.\n` +
+      `  items.json now returns the landscape2 SPA shell.\n` +
+      `  Current URL: ${FULL_JSON_URL}\n` +
+      `  Check https://landscape.cncf.io for the correct data endpoint.`
+    );
+  }
+
+  const data = (await resp.json()) as FullJsonResponse;
+  const items: FullJsonItem[] = Array.isArray(data.items) ? data.items : [];
+
+  if (items.length === 0) {
+    const topKeys = Object.keys(data).join(', ');
+    throw new Error(
+      `full.json returned 0 items. Top-level keys: [${topKeys}].\n` +
+      `  The response shape may have changed.`
+    );
+  }
+
+  console.log(`  Loaded ${items.length} landscape items`);
+
+  const byProjectName = new Map<string, ProjectMetadataWithSource>();
+
+  for (const item of items) {
+    // Only CNCF projects have a maturity field
+    if (!item.maturity) continue;
+
+    const repos: RepoRef[] = [];
+    for (const r of item.repositories || []) {
+      const ref = repoFromUrl(r.url, r.primary === true, r.branch);
+      if (ref) repos.push(ref);
+    }
+    if (repos.length === 0) continue;
+
+    const audits = item.audits || [];
+    const primaryRepo = repos.find(r => r.primary);
+    const project_name = item.name.replace(/[^a-zA-Z0-9\-_. ]/g, '');
+
+    const metadata: ProjectMetadataWithSource = {
+      project_name,
+      display_name: item.name,
+      description: item.summary?.use_case,
+      repos,
+      maturity: item.maturity,
+      category: item.category,
+      subcategory: item.subcategory,
+      date_accepted: item.accepted_at,
+      date_incubating: item.incubating_at,
+      date_graduated: item.graduated_at,
+      date_archived: item.archived_at,
+      homepage_url: item.homepage_url || item.website,
+      repo_url: primaryRepo ? `https://github.com/${primaryRepo.owner}/${primaryRepo.name}` : undefined,
+      blog_url: item.blog_url,
+      dev_stats_url: item.devstats_url,
+      clomonitor_name: item.clomonitor_name,
+      has_security_audits: audits.length > 0,
+      security_audit_count: audits.length,
+      latest_audit_date: audits.length > 0 ? audits[audits.length - 1].date : undefined,
+      latest_audit_vendor: audits.length > 0 ? audits[audits.length - 1].vendor : undefined,
+      crunchbase: item.crunchbase_url,
+      twitter: item.twitter_url,
+      source: 'landscape',
+    };
+
+    byProjectName.set(project_name.toLowerCase(), metadata);
+  }
+
+  console.log(`  Extracted ${byProjectName.size} CNCF projects from landscape`);
+  return byProjectName;
+}
+
+// ============================================================================
+// .PROJECT SOURCE
+// ============================================================================
+
+async function fetchDotProject(
+  org: string,
+  projectName: string,
+  githubToken: string | undefined,
+  verbose: boolean
+): Promise<DotProjectYaml | null> {
+  const headers: Record<string, string> = {
+    'User-Agent': 'supply-chain-security-collector/1.0',
+  };
+  // Token not needed for public repos on raw.githubusercontent.com but helps with rate limits
+  if (githubToken) {
+    headers['Authorization'] = `Bearer ${githubToken}`;
+  }
+
+  // Try main branch first, then master
+  for (const branch of ['main', 'master']) {
+    const url = `https://raw.githubusercontent.com/${org}/.project/${branch}/project.yaml`;
+    try {
+      const resp = await fetch(url, { headers });
+      if (resp.status === 404) continue;
+      if (resp.status === 403 || resp.status === 429) {
+        console.warn(`  [rate-limited] ${org}/.project (HTTP ${resp.status}) — set GITHUB_TOKEN to raise limits`);
+        return null;
+      }
+      if (!resp.ok) {
+        if (verbose) console.log(`    [${projectName}] ${org}/.project (${branch}): HTTP ${resp.status}`);
+        return null;
+      }
+      const text = await resp.text();
+      try {
+        const parsed = yaml.parse(text) as DotProjectYaml;
+        if (parsed && Array.isArray(parsed.repositories) && parsed.repositories.length > 0) {
+          return parsed;
+        }
+        return null;  // no repositories field or empty
+      } catch {
+        if (verbose) console.log(`    [${projectName}] YAML parse error for ${org}/.project`);
+        return null;
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(`    [${projectName}] fetch error: ${err instanceof Error ? err.message : err}`);
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+// ============================================================================
+// DEDUP HELPERS
+// ============================================================================
+
+function nwo(owner: string, name: string): string {
+  return `${owner}/${name}`.toLowerCase();
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+async function main() {
+  const { output, dotProject: fetchDotProjectData, dryRun, verbose } = parseArgs();
+
+  const githubToken =
+    process.env.GITHUB_TOKEN ||
+    process.env.GITHUB_PERSONAL_ACCESS_TOKEN ||
+    undefined;
+
+  console.log('');
+  console.log('CNCF Expanded Repo List Builder');
+  console.log('='.repeat(50));
+  console.log(`Sources: landscape (full.json)${fetchDotProjectData ? ' + .project repos' : ''}`);
+  if (githubToken) {
+    console.log('  GitHub token: set (rate limits raised)');
+  } else {
+    console.log('  GitHub token: not set (unauthenticated; set GITHUB_TOKEN to raise rate limits)');
+  }
+  console.log(`Output:  ${dryRun ? '[dry-run, no write]' : output}`);
+  console.log('');
+
+  // ── Step 1: Fetch landscape ──────────────────────────────────────────────
+  const projectsByName = await fetchLandscapeProjects();
+
+  // Build global nameWithOwner registry for dedup
+  const nwoRegistry = new Map<string, string>();  // nwo -> project_name
+  for (const [pname, meta] of projectsByName) {
+    for (const repo of meta.repos) {
+      nwoRegistry.set(nwo(repo.owner, repo.name), pname);
+    }
+  }
+
+  let landscapeRepoCount = 0;
+  for (const meta of projectsByName.values()) landscapeRepoCount += meta.repos.length;
+  console.log(`  Landscape repos: ${landscapeRepoCount} across ${projectsByName.size} projects`);
+
+  // ── Step 2: .project enrichment ──────────────────────────────────────────
+  let dotProjectFound = 0;
+  let dotProjectSkipped = 0;
+  let dotProjectAdded = 0;
+
+  if (fetchDotProjectData) {
+    console.log('\nFetching .project repos for CNCF projects...');
+    if (!githubToken) {
+      console.log('  (no GITHUB_TOKEN — using unauthenticated GETs; set token to avoid rate limits)');
+    }
+    console.log('  (projects without a .project repo are skipped gracefully)\n');
+
+    const projectList = Array.from(projectsByName.values());
+
+    // Process in small concurrent batches to avoid hammering GitHub
+    const BATCH_SIZE = 8;
+    const BATCH_DELAY_MS = 600;
+
+    for (let i = 0; i < projectList.length; i += BATCH_SIZE) {
+      const batch = projectList.slice(i, i + BATCH_SIZE);
+
+      await Promise.all(batch.map(async (meta) => {
+        const primaryRepo = meta.repos.find(r => r.primary) || meta.repos[0];
+        if (!primaryRepo) return;
+        const org = primaryRepo.owner;
+
+        const dotData = await fetchDotProject(org, meta.display_name || meta.project_name, githubToken, verbose);
+        if (!dotData) {
+          dotProjectSkipped++;
+          return;
+        }
+
+        dotProjectFound++;
+        const newRepos: string[] = [];
+
+        for (const repoUrl of dotData.repositories || []) {
+          const r = repoFromUrl(repoUrl, false);
+          if (!r) continue;
+          const key = nwo(r.owner, r.name);
+
+          if (!nwoRegistry.has(key)) {
+            // Net-new repo not captured by landscape — add to this project
+            meta.repos.push({ ...r, primary: false });
+            nwoRegistry.set(key, meta.project_name.toLowerCase());
+            newRepos.push(`${r.owner}/${r.name}`);
+            dotProjectAdded++;
+            if (verbose) {
+              console.log(`  + ${r.owner}/${r.name} (${meta.display_name} via .project)`);
+            }
+          }
+        }
+
+        if (newRepos.length > 0) {
+          meta.dot_project_repos = newRepos;
+          meta.source = 'both';
+        }
+      }));
+
+      if (i + BATCH_SIZE < projectList.length) {
+        await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+      }
+
+      const done = Math.min(i + BATCH_SIZE, projectList.length);
+      process.stdout.write(`\r  Progress: ${done}/${projectList.length} projects  `);
+    }
+    console.log('\n');
+
+    const enrichedProjects = Array.from(projectsByName.values()).filter(m => m.source === 'both');
+    console.log('.project summary:');
+    console.log(`  Projects with .project repo found:  ${dotProjectFound}`);
+    console.log(`    - contributed extra repos:        ${enrichedProjects.length} projects, ${dotProjectAdded} net-new repos`);
+    console.log(`  Projects without .project (404/skipped): ${dotProjectSkipped}`);
+  }
+
+  // ── Step 3: Final output ──────────────────────────────────────────────────
+  const finalProjects = Array.from(projectsByName.values());
+
+  const allNwo = new Set<string>();
+  for (const meta of finalProjects) {
+    for (const repo of meta.repos) {
+      allNwo.add(nwo(repo.owner, repo.name));
+    }
+  }
+
+  console.log('\nFinal counts:');
+  console.log(`  Projects:               ${finalProjects.length}`);
+  console.log(`  Total unique repos:     ${allNwo.size} (deduped on owner/name)`);
+  console.log(`    landscape-only:       ${finalProjects.filter(m => m.source === 'landscape').length} projects`);
+  console.log(`    enriched by .project: ${finalProjects.filter(m => m.source === 'both').length} projects`);
+
+  if (!dryRun) {
+    const outDir = path.dirname(output);
+    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(output, JSON.stringify(finalProjects, null, 2) + '\n');
+    console.log(`\nWritten: ${output}`);
+  } else {
+    console.log('\n[dry-run] No files written.');
+  }
+
+  console.log('\nDone.\n');
+}
+
+main().catch(err => {
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/build-repo-list.ts
+++ b/scripts/build-repo-list.ts
@@ -180,13 +180,15 @@ interface FullJsonResponse {
   [key: string]: unknown;
 }
 
-// .project project.yaml shape (what we need)
+// .project project.yaml shape (what we need).
+// `repositories` is typed `unknown` because hand-edited files sometimes use a
+// scalar string instead of a list; fetchDotProject() coerces + filters to string[].
 interface DotProjectYaml {
   schema_version?: string;
   slug?: string;
   name?: string;
   description?: string;
-  repositories?: string[];
+  repositories?: unknown;
   maturity_log?: Array<{ phase?: string; date?: string; issue?: string }>;
 }
 
@@ -308,39 +310,46 @@ async function fetchDotProject(
     headers['Authorization'] = `Bearer ${githubToken}`;
   }
 
-  // Try main branch first, then master
-  for (const branch of ['main', 'master']) {
-    const url = `https://raw.githubusercontent.com/${org}/.project/${branch}/project.yaml`;
-    try {
-      const resp = await fetch(url, { headers });
-      if (resp.status === 404) continue;
-      if (resp.status === 403 || resp.status === 429) {
-        console.warn(`  [rate-limited] ${org}/.project (HTTP ${resp.status}) — set GITHUB_TOKEN to raise limits`);
-        return null;
-      }
-      if (!resp.ok) {
-        if (verbose) console.log(`    [${projectName}] ${org}/.project (${branch}): HTTP ${resp.status}`);
-        return null;
-      }
-      const text = await resp.text();
-      try {
-        const parsed = yaml.parse(text) as DotProjectYaml;
-        if (parsed && Array.isArray(parsed.repositories) && parsed.repositories.length > 0) {
-          return parsed;
-        }
-        return null;  // no repositories field or empty
-      } catch {
-        if (verbose) console.log(`    [${projectName}] YAML parse error for ${org}/.project`);
-        return null;
-      }
-    } catch (err) {
-      if (verbose) {
-        console.log(`    [${projectName}] fetch error: ${err instanceof Error ? err.message : err}`);
-      }
+  // Resolve against the repo's DEFAULT BRANCH via the `HEAD` symbolic ref.
+  // raw.githubusercontent.com supports `.../HEAD/<path>`, which redirects to the
+  // default branch — no need to guess main-vs-master. This mirrors the GraphQL
+  // path in src/api.ts, which fetches `HEAD:project.yaml`.
+  const url = `https://raw.githubusercontent.com/${org}/.project/HEAD/project.yaml`;
+  try {
+    const resp = await fetch(url, { headers });
+    if (resp.status === 404) return null;
+    if (resp.status === 403 || resp.status === 429) {
+      console.warn(`  [rate-limited] ${org}/.project (HTTP ${resp.status}) — set GITHUB_TOKEN to raise limits`);
       return null;
     }
+    if (!resp.ok) {
+      if (verbose) console.log(`    [${projectName}] ${org}/.project (HEAD): HTTP ${resp.status}`);
+      return null;
+    }
+    const text = await resp.text();
+    try {
+      const parsed = yaml.parse(text) as DotProjectYaml;
+      // Defensive: repositories may be a scalar string (schema violation) rather
+      // than a list. Coerce scalar→array so single-repo .project files aren't dropped.
+      const rawRepos = parsed?.repositories;
+      const repos = rawRepos === undefined || rawRepos === null
+        ? []
+        : (Array.isArray(rawRepos) ? rawRepos : [rawRepos]);
+      const stringRepos = repos.filter((r): r is string => typeof r === 'string' && r.trim().length > 0);
+      if (parsed && stringRepos.length > 0) {
+        return { ...parsed, repositories: stringRepos };
+      }
+      return null;  // no usable repositories
+    } catch {
+      if (verbose) console.log(`    [${projectName}] YAML parse error for ${org}/.project`);
+      return null;
+    }
+  } catch (err) {
+    if (verbose) {
+      console.log(`    [${projectName}] fetch error: ${err instanceof Error ? err.message : err}`);
+    }
+    return null;
   }
-  return null;
 }
 
 // ============================================================================
@@ -425,7 +434,11 @@ async function main() {
         dotProjectFound++;
         const newRepos: string[] = [];
 
-        for (const repoUrl of dotData.repositories || []) {
+        // fetchDotProject() normalizes repositories to string[] on its non-null return.
+        const dotRepos: string[] = Array.isArray(dotData.repositories)
+          ? (dotData.repositories as string[])
+          : [];
+        for (const repoUrl of dotRepos) {
           const r = repoFromUrl(repoUrl, false);
           if (!r) continue;
           const key = nwo(r.owner, r.name);

--- a/scripts/test-dot-project-duckdb.ts
+++ b/scripts/test-dot-project-duckdb.ts
@@ -1,0 +1,266 @@
+/**
+ * test-dot-project-duckdb.ts
+ *
+ * Validates that parseDotProject output actually lands in DuckDB correctly.
+ * Uses an in-memory DuckDB instance — no token, no network required.
+ *
+ * Usage:
+ *   npx ts-node scripts/test-dot-project-duckdb.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { parseDotProject, mergeDotProjectResults } from '../src/normalizers/DotProjectNormalizer';
+import { installAndLoadExtensions } from '../src/duckdb-extensions';
+
+// Fixture: real open-telemetry data from test-dot-project-parse.ts
+const OTEL_YAML = `
+schema_version: "1.0.0"
+slug: "opentelemetry"
+name: "OpenTelemetry"
+description: "High-quality, ubiquitous, and portable telemetry to enable effective observability"
+type: "project"
+project_lead: "alolita"
+maturity_log:
+  - phase: "graduated"
+    date: "2019-05-07T00:00:00Z"
+    issue: "https://github.com/cncf/toc/issues/2152"
+repositories:
+  - "https://github.com/open-telemetry/community"
+  - "https://github.com/open-telemetry/opentelemetry-specification"
+website: "https://opentelemetry.io/"
+security:
+  policy:
+    path: "https://github.com/open-telemetry/.github/blob/main/SECURITY.md"
+  contact:
+    advisory_url: "https://github.com/open-telemetry/opentelemetry.io/security/advisories/new"
+landscape:
+  category: "Observability and Analysis"
+  subcategory: "Observability"
+`;
+
+const KUBERNETES_YAML = `
+schema_version: "1.0.0"
+slug: "kubernetes"
+name: "Kubernetes"
+description: "Container orchestration"
+type: "platform"
+project_lead:
+  - "thockin"
+  - "kubernetes/sig-leads"
+maturity_log:
+  - phase: "graduated"
+    date: "2018-03-06T00:00:00Z"
+    issue: "https://github.com/cncf/toc/issues/999"
+repositories:
+  - "https://github.com/kubernetes/kubernetes"
+audits:
+  - date: 2019-08-06T00:00:00Z
+    type: "security"
+    url: "https://example.com/audit1"
+security:
+  contact:
+    email: "security@kubernetes.io"
+`;
+
+const DOT_PROJECT_SCHEMAS = {
+    dot_project: `
+        org TEXT NOT NULL,
+        source_url TEXT NOT NULL,
+        schema_version TEXT,
+        slug TEXT,
+        name TEXT,
+        description TEXT,
+        type TEXT,
+        project_lead TEXT,
+        repository_count INTEGER,
+        website TEXT,
+        current_maturity TEXT,
+        current_maturity_date TEXT,
+        audit_count INTEGER,
+        security_policy_path TEXT,
+        security_threat_model_path TEXT,
+        security_contact_email TEXT,
+        security_advisory_url TEXT,
+        landscape_category TEXT,
+        landscape_subcategory TEXT,
+        package_managers_json TEXT,
+        fetched_at TIMESTAMP
+    `,
+    dot_project_repositories: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        repo_url TEXT NOT NULL,
+        repo_owner TEXT,
+        repo_name TEXT
+    `,
+    dot_project_maturity_log: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        phase TEXT,
+        date TEXT,
+        issue TEXT
+    `,
+    dot_project_audits: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        date TEXT,
+        type TEXT,
+        url TEXT
+    `,
+} as const;
+
+async function main() {
+    console.log('DotProjectNormalizer → DuckDB landing test');
+    console.log('='.repeat(50));
+
+    // Parse fixtures
+    const r1 = parseDotProject('open-telemetry', OTEL_YAML,
+        'https://github.com/open-telemetry/.project/blob/HEAD/project.yaml');
+    const r2 = parseDotProject('kubernetes', KUBERNETES_YAML,
+        'https://github.com/kubernetes/.project/blob/HEAD/project.yaml');
+
+    if (!r1 || !r2) {
+        console.error('FAIL: parseDotProject returned null for a fixture');
+        process.exit(1);
+    }
+
+    const merged = mergeDotProjectResults([r1, r2]);
+    console.log(`Parsed: ${merged.dot_project.length} projects, ${merged.dot_project_repositories.length} repos`);
+
+    // Write to a temp DuckDB
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dot-project-test-'));
+    const dbPath = path.join(tmpDir, 'test.db');
+    const db = await DuckDBInstance.create(dbPath);
+    const con = await db.connect();
+
+    try {
+        await installAndLoadExtensions(con);
+
+        // Write each table using the same pattern as writeDotProjectArtifacts
+        for (const [tableName, data] of [
+            ['dot_project', merged.dot_project],
+            ['dot_project_repositories', merged.dot_project_repositories],
+            ['dot_project_maturity_log', merged.dot_project_maturity_log],
+            ['dot_project_audits', merged.dot_project_audits],
+        ] as const) {
+            const schema = DOT_PROJECT_SCHEMAS[tableName];
+            if (data.length > 0) {
+                const tempPath = path.join(tmpDir, `temp_${tableName}.json`);
+                fs.writeFileSync(tempPath, JSON.stringify(data));
+                await con.run(`
+                    CREATE TABLE ${tableName} AS
+                    SELECT * FROM read_json('${tempPath}', format='array', auto_detect=true, union_by_name=true)
+                `);
+                fs.unlinkSync(tempPath);
+            } else {
+                await con.run(`CREATE TABLE ${tableName} (${schema})`);
+            }
+            console.log(`  Created: ${tableName} (${(data as unknown[]).length} rows)`);
+        }
+
+        // Query and validate
+        console.log('\n── dot_project ──');
+        const dpResult = await con.run(`
+            SELECT org, slug, name, current_maturity, repository_count, audit_count,
+                   security_advisory_url IS NOT NULL AS has_advisory,
+                   security_contact_email,
+                   landscape_category
+            FROM dot_project
+            ORDER BY org
+        `);
+        const dpRows = await dpResult.getRows();
+        for (const row of dpRows) {
+            console.log(row);
+        }
+
+        console.log('\n── dot_project_repositories ──');
+        const repoResult = await con.run(`
+            SELECT org, repo_owner, repo_name, position
+            FROM dot_project_repositories
+            ORDER BY org, position
+        `);
+        const repoRows = await repoResult.getRows();
+        for (const row of repoRows) {
+            console.log(row);
+        }
+
+        console.log('\n── dot_project_maturity_log ──');
+        const matResult = await con.run(`
+            SELECT org, phase, date, position
+            FROM dot_project_maturity_log
+            ORDER BY org, position
+        `);
+        const matRows = await matResult.getRows();
+        for (const row of matRows) {
+            console.log(row);
+        }
+
+        console.log('\n── dot_project_audits ──');
+        const auditResult = await con.run(`
+            SELECT org, type, url, position
+            FROM dot_project_audits
+            ORDER BY org, position
+        `);
+        const auditRows = await auditResult.getRows();
+        for (const row of auditRows) {
+            console.log(row);
+        }
+
+        // Assertions on query results
+        console.log('\n── Assertions ──');
+
+        function assert(cond: boolean, msg: string) {
+            if (!cond) { console.error(`  FAIL: ${msg}`); process.exitCode = 1; }
+            else console.log(`  PASS: ${msg}`);
+        }
+
+        assert(dpRows.length === 2, `dot_project has 2 rows (got ${dpRows.length})`);
+
+        // Row ordering: open-telemetry < kubernetes alphabetically
+        const otelRow = dpRows.find(r => r[0] === 'open-telemetry');
+        const k8sRow = dpRows.find(r => r[0] === 'kubernetes');
+
+        assert(otelRow !== undefined, 'open-telemetry row exists');
+        assert(k8sRow !== undefined, 'kubernetes row exists');
+
+        if (otelRow) {
+            assert(otelRow[1] === 'opentelemetry', `otel slug = opentelemetry (got ${otelRow[1]})`);
+            assert(otelRow[3] === 'graduated', `otel maturity = graduated (got ${otelRow[3]})`);
+            assert(Number(otelRow[4]) === 2, `otel repository_count = 2 (got ${otelRow[4]})`);
+            assert(otelRow[6] === true, 'otel has_advisory = true');
+        }
+
+        if (k8sRow) {
+            assert(k8sRow[1] === 'kubernetes', `k8s slug = kubernetes (got ${k8sRow[1]})`);
+            assert(Number(k8sRow[5]) === 1, `k8s audit_count = 1 (got ${k8sRow[5]})`);
+            assert(k8sRow[7] === 'security@kubernetes.io', `k8s security_contact_email set`);
+        }
+
+        assert(repoRows.length === 3, `dot_project_repositories has 3 rows (got ${repoRows.length})`);
+        assert(matRows.length === 2, `dot_project_maturity_log has 2 rows (got ${matRows.length})`);
+        assert(auditRows.length === 1, `dot_project_audits has 1 row (got ${auditRows.length})`);
+
+        await con.run('CHECKPOINT');
+    } finally {
+        try { con.closeSync(); } catch { /* ignore */ }
+    }
+
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true });
+
+    const exitCode = process.exitCode ?? 0;
+    console.log(`\n${'='.repeat(50)}`);
+    if (exitCode === 0) {
+        console.log('All DuckDB landing tests passed.');
+    } else {
+        console.error('Some DuckDB landing tests FAILED.');
+    }
+}
+
+main().catch(err => {
+    console.error('Error:', err);
+    process.exit(1);
+});

--- a/scripts/test-dot-project-duckdb.ts
+++ b/scripts/test-dot-project-duckdb.ts
@@ -1,8 +1,14 @@
 /**
  * test-dot-project-duckdb.ts
  *
- * Validates that parseDotProject output actually lands in DuckDB correctly.
- * Uses an in-memory DuckDB instance — no token, no network required.
+ * Validates that .project data actually lands in DuckDB correctly by driving the
+ * REAL writeDotProjectArtifacts() production path with synthetic GraphQL
+ * responses — no token, no network. Confirms:
+ *   - all five dot_project* tables are created
+ *   - PRIMARY KEY on dot_project(org) is enforced
+ *   - date columns land as TIMESTAMP (aligned with fetched_at), not TEXT
+ *   - maintainers.yaml is parsed into dot_project_maintainers
+ *   - a malformed project.yaml for one org does NOT abort the write
  *
  * Usage:
  *   npx ts-node scripts/test-dot-project-duckdb.ts
@@ -12,10 +18,37 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { DuckDBInstance } from '@duckdb/node-api';
-import { parseDotProject, mergeDotProjectResults } from '../src/normalizers/DotProjectNormalizer';
-import { installAndLoadExtensions } from '../src/duckdb-extensions';
+import { writeDotProjectArtifacts } from '../src/ArtifactWriter';
+import type { GetDotProjectDataResponse } from '../src/api';
 
-// Fixture: real open-telemetry data from test-dot-project-parse.ts
+// Helper: build a synthetic GraphQL response as fetchDotProjectData would return.
+function makeResponse(
+    org: string,
+    projectYamlText: string | null,
+    maintainersYamlText: string | null = null,
+    oid: string | null = null
+): { org: string; data: GetDotProjectDataResponse } {
+    return {
+        org,
+        data: {
+            repository: {
+                __typename: 'Repository',
+                id: `id_${org}`,
+                nameWithOwner: `${org}/.project`,
+                defaultBranchRef: oid
+                    ? { name: 'main', target: { oid } }
+                    : { name: 'main', target: null },
+                projectYaml: projectYamlText === null
+                    ? null
+                    : { __typename: 'Blob', id: `blob_${org}`, text: projectYamlText },
+                maintainersYaml: maintainersYamlText === null
+                    ? null
+                    : { __typename: 'Blob', id: `mblob_${org}`, text: maintainersYamlText },
+            },
+        },
+    };
+}
+
 const OTEL_YAML = `
 schema_version: "1.0.0"
 slug: "opentelemetry"
@@ -65,194 +98,190 @@ security:
     email: "security@kubernetes.io"
 `;
 
-const DOT_PROJECT_SCHEMAS = {
-    dot_project: `
-        org TEXT NOT NULL,
-        source_url TEXT NOT NULL,
-        schema_version TEXT,
-        slug TEXT,
-        name TEXT,
-        description TEXT,
-        type TEXT,
-        project_lead TEXT,
-        repository_count INTEGER,
-        website TEXT,
-        current_maturity TEXT,
-        current_maturity_date TEXT,
-        audit_count INTEGER,
-        security_policy_path TEXT,
-        security_threat_model_path TEXT,
-        security_contact_email TEXT,
-        security_advisory_url TEXT,
-        landscape_category TEXT,
-        landscape_subcategory TEXT,
-        package_managers_json TEXT,
-        fetched_at TIMESTAMP
-    `,
-    dot_project_repositories: `
-        org TEXT NOT NULL,
-        position INTEGER NOT NULL,
-        repo_url TEXT NOT NULL,
-        repo_owner TEXT,
-        repo_name TEXT
-    `,
-    dot_project_maturity_log: `
-        org TEXT NOT NULL,
-        position INTEGER NOT NULL,
-        phase TEXT,
-        date TEXT,
-        issue TEXT
-    `,
-    dot_project_audits: `
-        org TEXT NOT NULL,
-        position INTEGER NOT NULL,
-        date TEXT,
-        type TEXT,
-        url TEXT
-    `,
-} as const;
+const KUBERNETES_MAINTAINERS_YAML = `
+maintainers:
+  - project_id: "kubernetes"
+    org: "kubernetes"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - "@thockin"
+          - "dims"
+`;
+
+// A DELIBERATELY malformed project.yaml (scalar repositories + numeric lead +
+// non-string repo entries) that would have CRASHED the old code. It must be
+// tolerated: parsed defensively and NOT abort the write of the other orgs.
+const MALFORMED_YAML = `
+schema_version: "1.0.0"
+slug: "malformed"
+name: "Malformed Project"
+project_lead: 42
+repositories: "https://github.com/malformed-org/only-repo"
+maturity_log: "not-a-list"
+`;
 
 async function main() {
-    console.log('DotProjectNormalizer → DuckDB landing test');
-    console.log('='.repeat(50));
+    console.log('writeDotProjectArtifacts → DuckDB landing test (real production path)');
+    console.log('='.repeat(60));
 
-    // Parse fixtures
-    const r1 = parseDotProject('open-telemetry', OTEL_YAML,
-        'https://github.com/open-telemetry/.project/blob/HEAD/project.yaml');
-    const r2 = parseDotProject('kubernetes', KUBERNETES_YAML,
-        'https://github.com/kubernetes/.project/blob/HEAD/project.yaml');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dot-project-test-'));
+    const dbPath = path.join(tmpDir, 'database.db');
 
-    if (!r1 || !r2) {
-        console.error('FAIL: parseDotProject returned null for a fixture');
+    // Pre-create an empty database.db (writeDotProjectArtifacts opens an existing one)
+    {
+        const db = await DuckDBInstance.create(dbPath);
+        const con = await db.connect();
+        await con.run('CREATE TABLE _placeholder (x INTEGER)');
+        await con.run('CHECKPOINT');
+        con.closeSync();
+    }
+
+    // Drive the REAL production function with synthetic responses, including:
+    //  - open-telemetry (2 repos, advisory url)
+    //  - kubernetes (1 repo, 1 audit, email, maintainers.yaml, resolved oid → permalink)
+    //  - malformed (scalar/numeric junk that must not crash)
+    //  - ghost (repo exists but no project.yaml → skipped)
+    const responses = [
+        makeResponse('open-telemetry', OTEL_YAML),
+        makeResponse('kubernetes', KUBERNETES_YAML, KUBERNETES_MAINTAINERS_YAML, 'abc123def456'),
+        makeResponse('malformed-org', MALFORMED_YAML),
+        makeResponse('ghost-org', null),
+    ];
+
+    try {
+        await writeDotProjectArtifacts(responses, tmpDir);
+    } catch (err) {
+        console.error('FAIL: writeDotProjectArtifacts threw (should never happen):', err);
         process.exit(1);
     }
 
-    const merged = mergeDotProjectResults([r1, r2]);
-    console.log(`Parsed: ${merged.dot_project.length} projects, ${merged.dot_project_repositories.length} repos`);
-
-    // Write to a temp DuckDB
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dot-project-test-'));
-    const dbPath = path.join(tmpDir, 'test.db');
+    // Re-open and validate
     const db = await DuckDBInstance.create(dbPath);
     const con = await db.connect();
 
+    function assert(cond: boolean, msg: string) {
+        if (!cond) { console.error(`  FAIL: ${msg}`); process.exitCode = 1; }
+        else console.log(`  PASS: ${msg}`);
+    }
+
     try {
-        await installAndLoadExtensions(con);
-
-        // Write each table using the same pattern as writeDotProjectArtifacts
-        for (const [tableName, data] of [
-            ['dot_project', merged.dot_project],
-            ['dot_project_repositories', merged.dot_project_repositories],
-            ['dot_project_maturity_log', merged.dot_project_maturity_log],
-            ['dot_project_audits', merged.dot_project_audits],
-        ] as const) {
-            const schema = DOT_PROJECT_SCHEMAS[tableName];
-            if (data.length > 0) {
-                const tempPath = path.join(tmpDir, `temp_${tableName}.json`);
-                fs.writeFileSync(tempPath, JSON.stringify(data));
-                await con.run(`
-                    CREATE TABLE ${tableName} AS
-                    SELECT * FROM read_json('${tempPath}', format='array', auto_detect=true, union_by_name=true)
-                `);
-                fs.unlinkSync(tempPath);
-            } else {
-                await con.run(`CREATE TABLE ${tableName} (${schema})`);
-            }
-            console.log(`  Created: ${tableName} (${(data as unknown[]).length} rows)`);
-        }
-
-        // Query and validate
-        console.log('\n── dot_project ──');
-        const dpResult = await con.run(`
-            SELECT org, slug, name, current_maturity, repository_count, audit_count,
-                   security_advisory_url IS NOT NULL AS has_advisory,
-                   security_contact_email,
-                   landscape_category
-            FROM dot_project
-            ORDER BY org
-        `);
-        const dpRows = await dpResult.getRows();
-        for (const row of dpRows) {
-            console.log(row);
-        }
-
-        console.log('\n── dot_project_repositories ──');
-        const repoResult = await con.run(`
-            SELECT org, repo_owner, repo_name, position
-            FROM dot_project_repositories
-            ORDER BY org, position
-        `);
-        const repoRows = await repoResult.getRows();
-        for (const row of repoRows) {
-            console.log(row);
-        }
-
-        console.log('\n── dot_project_maturity_log ──');
-        const matResult = await con.run(`
-            SELECT org, phase, date, position
-            FROM dot_project_maturity_log
-            ORDER BY org, position
-        `);
-        const matRows = await matResult.getRows();
-        for (const row of matRows) {
-            console.log(row);
-        }
-
-        console.log('\n── dot_project_audits ──');
-        const auditResult = await con.run(`
-            SELECT org, type, url, position
-            FROM dot_project_audits
-            ORDER BY org, position
-        `);
-        const auditRows = await auditResult.getRows();
-        for (const row of auditRows) {
-            console.log(row);
-        }
-
-        // Assertions on query results
         console.log('\n── Assertions ──');
 
-        function assert(cond: boolean, msg: string) {
-            if (!cond) { console.error(`  FAIL: ${msg}`); process.exitCode = 1; }
-            else console.log(`  PASS: ${msg}`);
+        // All five tables exist
+        const tablesResult = await con.run(`
+            SELECT table_name FROM information_schema.tables
+            WHERE table_schema='main' AND table_name LIKE 'dot_project%'
+            ORDER BY table_name
+        `);
+        const tableNames = (await tablesResult.getRows()).map(r => String(r[0]));
+        console.log('  Tables:', tableNames.join(', '));
+        for (const t of ['dot_project', 'dot_project_audits', 'dot_project_maintainers',
+                         'dot_project_maturity_log', 'dot_project_repositories']) {
+            assert(tableNames.includes(t), `table ${t} exists`);
         }
 
-        assert(dpRows.length === 2, `dot_project has 2 rows (got ${dpRows.length})`);
+        // Row counts: malformed-org still lands (defensive parse); ghost-org does not
+        const dpCount = await con.run('SELECT count(*) FROM dot_project');
+        const dpRows = Number((await dpCount.getRows())[0][0]);
+        assert(dpRows === 3, `dot_project has 3 rows (otel, k8s, malformed; ghost skipped) — got ${dpRows}`);
 
-        // Row ordering: open-telemetry < kubernetes alphabetically
-        const otelRow = dpRows.find(r => r[0] === 'open-telemetry');
-        const k8sRow = dpRows.find(r => r[0] === 'kubernetes');
+        // PRIMARY KEY on org is enforced
+        const pkResult = await con.run(`
+            SELECT constraint_type FROM information_schema.table_constraints
+            WHERE table_name='dot_project' AND constraint_type='PRIMARY KEY'
+        `);
+        const pkRows = await pkResult.getRows();
+        assert(pkRows.length >= 1, 'dot_project has a PRIMARY KEY constraint');
 
-        assert(otelRow !== undefined, 'open-telemetry row exists');
-        assert(k8sRow !== undefined, 'kubernetes row exists');
-
-        if (otelRow) {
-            assert(otelRow[1] === 'opentelemetry', `otel slug = opentelemetry (got ${otelRow[1]})`);
-            assert(otelRow[3] === 'graduated', `otel maturity = graduated (got ${otelRow[3]})`);
-            assert(Number(otelRow[4]) === 2, `otel repository_count = 2 (got ${otelRow[4]})`);
-            assert(otelRow[6] === true, 'otel has_advisory = true');
+        // Inserting a duplicate org must violate the PK
+        let pkViolated = false;
+        try {
+            await con.run(`
+                INSERT INTO dot_project (org, source_url) VALUES ('kubernetes', 'dup')
+            `);
+        } catch {
+            pkViolated = true;
         }
+        assert(pkViolated, 'duplicate org insert rejected by PRIMARY KEY');
 
-        if (k8sRow) {
-            assert(k8sRow[1] === 'kubernetes', `k8s slug = kubernetes (got ${k8sRow[1]})`);
-            assert(Number(k8sRow[5]) === 1, `k8s audit_count = 1 (got ${k8sRow[5]})`);
-            assert(k8sRow[7] === 'security@kubernetes.io', `k8s security_contact_email set`);
+        // Column types: date columns are TIMESTAMP, aligned with fetched_at
+        const typesResult = await con.run(`
+            SELECT column_name, data_type FROM information_schema.columns
+            WHERE table_name='dot_project'
+              AND column_name IN ('current_maturity_date', 'fetched_at')
+        `);
+        const typeMap = new Map<string, string>();
+        for (const row of await typesResult.getRows()) {
+            typeMap.set(String(row[0]), String(row[1]));
         }
+        console.log('  dot_project column types:', JSON.stringify(Object.fromEntries(typeMap)));
+        assert(typeMap.get('current_maturity_date') === 'TIMESTAMP', `current_maturity_date is TIMESTAMP (got ${typeMap.get('current_maturity_date')})`);
+        assert(typeMap.get('fetched_at') === 'TIMESTAMP', `fetched_at is TIMESTAMP (got ${typeMap.get('fetched_at')})`);
 
-        assert(repoRows.length === 3, `dot_project_repositories has 3 rows (got ${repoRows.length})`);
-        assert(matRows.length === 2, `dot_project_maturity_log has 2 rows (got ${matRows.length})`);
-        assert(auditRows.length === 1, `dot_project_audits has 1 row (got ${auditRows.length})`);
+        const matDateType = await con.run(`
+            SELECT data_type FROM information_schema.columns
+            WHERE table_name='dot_project_maturity_log' AND column_name='date'
+        `);
+        assert(String((await matDateType.getRows())[0][0]) === 'TIMESTAMP', 'dot_project_maturity_log.date is TIMESTAMP');
 
-        await con.run('CHECKPOINT');
+        // Content spot-checks
+        const otel = await con.run(`
+            SELECT slug, current_maturity, repository_count, current_maturity_date
+            FROM dot_project WHERE org='open-telemetry'
+        `);
+        const otelRow = (await otel.getRows())[0];
+        console.log('  open-telemetry:', otelRow);
+        assert(otelRow[0] === 'opentelemetry', 'otel slug');
+        assert(otelRow[1] === 'graduated', 'otel maturity');
+        assert(Number(otelRow[2]) === 2, 'otel repository_count = 2');
+        assert(otelRow[3] !== null, 'otel current_maturity_date populated (TIMESTAMP cast worked)');
+
+        // malformed-org: numeric project_lead dropped, scalar repo coerced to 1
+        const mal = await con.run(`
+            SELECT project_lead, repository_count FROM dot_project WHERE org='malformed-org'
+        `);
+        const malRow = (await mal.getRows())[0];
+        console.log('  malformed-org:', malRow);
+        assert(malRow[0] === null, 'malformed project_lead=42 dropped to NULL (not "42")');
+        assert(Number(malRow[1]) === 1, 'malformed scalar repositories coerced to 1');
+
+        // repositories rows
+        const repoCount = await con.run('SELECT count(*) FROM dot_project_repositories');
+        const repoRows = Number((await repoCount.getRows())[0][0]);
+        assert(repoRows === 4, `dot_project_repositories has 4 rows (otel 2 + k8s 1 + malformed 1) — got ${repoRows}`);
+
+        // audits
+        const auditCount = await con.run('SELECT count(*) FROM dot_project_audits');
+        assert(Number((await auditCount.getRows())[0][0]) === 1, 'dot_project_audits has 1 row (k8s)');
+
+        // maintainers (from kubernetes maintainers.yaml)
+        const maintCount = await con.run('SELECT count(*) FROM dot_project_maintainers');
+        const maintRows = Number((await maintCount.getRows())[0][0]);
+        assert(maintRows === 2, `dot_project_maintainers has 2 rows (thockin, dims) — got ${maintRows}`);
+
+        const maintDetail = await con.run(`
+            SELECT member, team FROM dot_project_maintainers ORDER BY member
+        `);
+        const maintDetailRows = await maintDetail.getRows();
+        console.log('  maintainers:', maintDetailRows);
+        assert(maintDetailRows.some(r => r[0] === 'thockin'), 'thockin present (@ stripped)');
+        assert(maintDetailRows.some(r => r[0] === 'dims'), 'dims present');
+
+        // Parquet files exported
+        const parquetDir = path.join(tmpDir, 'parquet');
+        for (const t of ['dot_project', 'dot_project_repositories', 'dot_project_maturity_log',
+                         'dot_project_audits', 'dot_project_maintainers']) {
+            assert(fs.existsSync(path.join(parquetDir, `${t}.parquet`)), `${t}.parquet exported`);
+        }
     } finally {
         try { con.closeSync(); } catch { /* ignore */ }
     }
 
-    // Cleanup
     fs.rmSync(tmpDir, { recursive: true });
 
     const exitCode = process.exitCode ?? 0;
-    console.log(`\n${'='.repeat(50)}`);
+    console.log(`\n${'='.repeat(60)}`);
     if (exitCode === 0) {
         console.log('All DuckDB landing tests passed.');
     } else {

--- a/scripts/test-dot-project-parse.ts
+++ b/scripts/test-dot-project-parse.ts
@@ -1,0 +1,259 @@
+/**
+ * test-dot-project-parse.ts
+ *
+ * Standalone validation script for DotProjectNormalizer.
+ * Runs without a GitHub token — tests the YAML parse and normalization logic
+ * against the real open-telemetry/.project/project.yaml fetched via
+ * unauthenticated raw.githubusercontent.com.
+ *
+ * Usage:
+ *   npx ts-node scripts/test-dot-project-parse.ts
+ *
+ * Also validates the example from the .project schema:
+ *   ~/gh/f/cncf/automation/utilities/dot-project/example/project.yaml
+ */
+
+import * as https from 'https';
+import { parseDotProject, mergeDotProjectResults, getDotProjectStats } from '../src/normalizers/DotProjectNormalizer';
+
+// ---------------------------------------------------------------------------
+// Inline example fixture (mirrors the schema example — kubernetes)
+// ---------------------------------------------------------------------------
+const KUBERNETES_EXAMPLE_YAML = `
+schema_version: "1.0.0"
+slug: "kubernetes"
+name: "Kubernetes"
+description: "Kubernetes is an open-source system for automating deployment, scaling, and management of containerized applications."
+type: "platform"
+project_lead:
+  - "thockin"
+  - "kubernetes/sig-leads"
+maturity_log:
+  - phase: "sandbox"
+    date: 2016-03-10T00:00:00Z
+    issue: "https://github.com/cncf/toc/issues/123"
+  - phase: "incubating"
+    date: 2017-03-01T00:00:00Z
+    issue: "https://github.com/cncf/toc/issues/123"
+  - phase: "graduated"
+    date: 2018-03-06T00:00:00Z
+    issue: "https://github.com/cncf/toc/issues/123"
+repositories:
+  - "https://github.com/kubernetes/kubernetes"
+  - "https://github.com/kubernetes/kubectl"
+  - "https://github.com/kubernetes/client-go"
+  - "https://github.com/kubernetes/api"
+website: "https://kubernetes.io"
+audits:
+  - date: 2019-08-06T00:00:00Z
+    type: "security"
+    url: "https://example.com/audit1"
+  - date: 2021-05-17T00:00:00Z
+    type: "security"
+    url: "https://example.com/audit2"
+security:
+  policy:
+    path: "https://github.com/kubernetes/kubernetes/blob/master/SECURITY.md"
+  threat_model:
+    path: "https://github.com/kubernetes/community/blob/master/sig-security/threat-model.md"
+  contact:
+    email: security@kubernetes.io
+    advisory_url: "https://github.com/kubernetes/kubernetes/security/advisories/new"
+landscape:
+  category: "Orchestration & Management"
+  subcategory: "Scheduling & Orchestration"
+package_managers:
+  homebrew: "kubernetes-cli"
+  chocolatey: "kubernetes-cli"
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fetchUrl(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    https.get(url, { timeout: 10000 }, (res) => {
+      if (res.statusCode === 404) {
+        reject(new Error(`HTTP 404: ${url}`));
+        return;
+      }
+      let data = '';
+      res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+      res.on('end', () => resolve(data));
+      res.on('error', reject);
+    }).on('error', reject).on('timeout', () => reject(new Error(`Timeout: ${url}`)));
+  });
+}
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`  PASS: ${msg}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Inline kubernetes example (no network)
+// ---------------------------------------------------------------------------
+
+function testKubernetesExample(): void {
+  console.log('\n══ Test 1: Kubernetes example (inline fixture, no network) ══\n');
+
+  const result = parseDotProject(
+    'kubernetes',
+    KUBERNETES_EXAMPLE_YAML,
+    'https://github.com/kubernetes/.project/blob/HEAD/project.yaml'
+  );
+
+  if (!result) {
+    console.error('FAIL: parseDotProject returned null for kubernetes example');
+    process.exitCode = 1;
+    return;
+  }
+
+  const dp = result.dot_project[0];
+  console.log('dot_project record:');
+  console.log(JSON.stringify(dp, null, 2));
+
+  console.log('\nAssertions:');
+  assert(dp.org === 'kubernetes', `org = 'kubernetes' (got '${dp.org}')`);
+  assert(dp.slug === 'kubernetes', `slug = 'kubernetes' (got '${dp.slug}')`);
+  assert(dp.name === 'Kubernetes', `name = 'Kubernetes' (got '${dp.name}')`);
+  assert(dp.type === 'platform', `type = 'platform' (got '${dp.type}')`);
+  assert(dp.current_maturity === 'graduated', `current_maturity = 'graduated' (got '${dp.current_maturity}')`);
+  assert(dp.project_lead === 'thockin, kubernetes/sig-leads', `project_lead = 'thockin, kubernetes/sig-leads' (got '${dp.project_lead}')`);
+  assert(dp.repository_count === 4, `repository_count = 4 (got ${dp.repository_count})`);
+  assert(dp.audit_count === 2, `audit_count = 2 (got ${dp.audit_count})`);
+  assert(dp.security_policy_path === 'https://github.com/kubernetes/kubernetes/blob/master/SECURITY.md', 'security_policy_path set');
+  assert(dp.security_threat_model_path !== null, 'security_threat_model_path set');
+  assert(dp.security_contact_email === 'security@kubernetes.io', `security_contact_email set (got '${dp.security_contact_email}')`);
+  assert(dp.security_advisory_url !== null, 'security_advisory_url set');
+  assert(dp.landscape_category === 'Orchestration & Management', `landscape_category set (got '${dp.landscape_category}')`);
+  assert(dp.landscape_subcategory === 'Scheduling & Orchestration', `landscape_subcategory set`);
+  assert(dp.package_managers_json !== null, 'package_managers_json set');
+
+  console.log('\ndot_project_repositories:');
+  console.log(JSON.stringify(result.dot_project_repositories, null, 2));
+  assert(result.dot_project_repositories.length === 4, `4 repositories (got ${result.dot_project_repositories.length})`);
+  assert(result.dot_project_repositories[0].repo_owner === 'kubernetes', 'first repo owner = kubernetes');
+  assert(result.dot_project_repositories[0].repo_name === 'kubernetes', 'first repo name = kubernetes');
+
+  console.log('\ndot_project_maturity_log:');
+  console.log(JSON.stringify(result.dot_project_maturity_log, null, 2));
+  assert(result.dot_project_maturity_log.length === 3, `3 maturity entries (got ${result.dot_project_maturity_log.length})`);
+  assert(result.dot_project_maturity_log[0].phase === 'sandbox', 'first phase = sandbox');
+  assert(result.dot_project_maturity_log[2].phase === 'graduated', 'last phase = graduated');
+
+  console.log('\ndot_project_audits:');
+  console.log(JSON.stringify(result.dot_project_audits, null, 2));
+  assert(result.dot_project_audits.length === 2, `2 audits (got ${result.dot_project_audits.length})`);
+  assert(result.dot_project_audits[0].type === 'security', `audit[0].type = security`);
+
+  console.log('\n' + getDotProjectStats(result));
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Real open-telemetry/.project via unauthenticated raw fetch
+// ---------------------------------------------------------------------------
+
+async function testOpenTelemetry(): Promise<void> {
+  console.log('\n══ Test 2: open-telemetry/.project (live unauthenticated fetch) ══\n');
+
+  const url = 'https://raw.githubusercontent.com/open-telemetry/.project/main/project.yaml';
+  let yamlText: string;
+  try {
+    yamlText = await fetchUrl(url);
+    console.log(`Fetched ${yamlText.length} bytes from ${url}`);
+  } catch (err) {
+    console.warn(`  SKIP: network unavailable or 404 (${err instanceof Error ? err.message : err})`);
+    return;
+  }
+
+  const result = parseDotProject(
+    'open-telemetry',
+    yamlText,
+    'https://github.com/open-telemetry/.project/blob/HEAD/project.yaml'
+  );
+
+  if (!result) {
+    console.error('FAIL: parseDotProject returned null for open-telemetry');
+    process.exitCode = 1;
+    return;
+  }
+
+  const dp = result.dot_project[0];
+  console.log('dot_project record:');
+  console.log(JSON.stringify(dp, null, 2));
+
+  console.log('\nAssertions:');
+  assert(dp.org === 'open-telemetry', `org = 'open-telemetry' (got '${dp.org}')`);
+  assert(dp.slug === 'opentelemetry', `slug = 'opentelemetry' (got '${dp.slug}')`);
+  assert(dp.name === 'OpenTelemetry', `name = 'OpenTelemetry' (got '${dp.name}')`);
+  assert(dp.current_maturity === 'graduated', `current_maturity = 'graduated' (got '${dp.current_maturity}')`);
+  assert(dp.security_policy_path !== null, 'security_policy_path set');
+  assert(dp.security_advisory_url !== null, 'security_advisory_url set');
+  assert(dp.landscape_category === 'Observability and Analysis', `landscape_category set (got '${dp.landscape_category}')`);
+  assert(result.dot_project_repositories.length >= 1, `at least 1 repository (got ${result.dot_project_repositories.length})`);
+  assert(result.dot_project_repositories[0].repo_owner === 'open-telemetry', 'first repo owner = open-telemetry');
+  assert(result.dot_project_maturity_log.length >= 1, `at least 1 maturity_log entry (got ${result.dot_project_maturity_log.length})`);
+
+  console.log('\n' + getDotProjectStats(result));
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: null on invalid YAML
+// ---------------------------------------------------------------------------
+
+function testInvalidYaml(): void {
+  console.log('\n══ Test 3: Invalid YAML returns null ══\n');
+  const result = parseDotProject('test-org', ': this is not valid yaml: [', 'test-url');
+  assert(result === null, 'invalid YAML returns null');
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: merge multiple results
+// ---------------------------------------------------------------------------
+
+function testMerge(): void {
+  console.log('\n══ Test 4: mergeDotProjectResults ══\n');
+
+  const r1 = parseDotProject('kubernetes', KUBERNETES_EXAMPLE_YAML, 'test-url-1');
+  const r2 = null; // parse failure / missing repo
+  const r3 = parseDotProject('kubernetes', KUBERNETES_EXAMPLE_YAML, 'test-url-3'); // same org, 2nd entry
+
+  const merged = mergeDotProjectResults([r1, r2, r3]);
+  assert(merged.dot_project.length === 2, `merged dot_project has 2 rows (got ${merged.dot_project.length})`);
+  assert(merged.dot_project_repositories.length === 8, `merged repos has 8 rows (got ${merged.dot_project_repositories.length})`);
+  assert(merged.dot_project_maturity_log.length === 6, `merged maturity_log has 6 rows (got ${merged.dot_project_maturity_log.length})`);
+  assert(merged.dot_project_audits.length === 4, `merged audits has 4 rows (got ${merged.dot_project_audits.length})`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log('DotProjectNormalizer — parse validation');
+  console.log('='.repeat(50));
+
+  testKubernetesExample();
+  await testOpenTelemetry();
+  testInvalidYaml();
+  testMerge();
+
+  const exitCode = process.exitCode ?? 0;
+  console.log(`\n${'='.repeat(50)}`);
+  if (exitCode === 0) {
+    console.log('All tests passed.');
+  } else {
+    console.error(`${exitCode} test(s) failed.`);
+  }
+}
+
+main().catch(err => {
+  console.error('Test runner error:', err);
+  process.exit(1);
+});

--- a/scripts/test-dot-project-parse.ts
+++ b/scripts/test-dot-project-parse.ts
@@ -14,7 +14,12 @@
  */
 
 import * as https from 'https';
-import { parseDotProject, mergeDotProjectResults, getDotProjectStats } from '../src/normalizers/DotProjectNormalizer';
+import {
+  parseDotProject,
+  parseMaintainers,
+  mergeDotProjectResults,
+  getDotProjectStats,
+} from '../src/normalizers/DotProjectNormalizer';
 
 // ---------------------------------------------------------------------------
 // Inline example fixture (mirrors the schema example — kubernetes)
@@ -232,6 +237,203 @@ function testMerge(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Test 5: BLOCKING edge cases — malformed .project files must NOT crash
+// ---------------------------------------------------------------------------
+
+function testMalformedEdgeCases(): void {
+  console.log('\n══ Test 5: Malformed .project edge cases (must never throw) ══\n');
+
+  // 5a: repositories is a SCALAR string, not a sequence.
+  // Before the fix, `rawRepos.map` threw "map is not a function".
+  {
+    const yamlText = `
+schema_version: "1.0.0"
+slug: "scalar-repo"
+name: "Scalar Repo"
+maturity_log:
+  - phase: "sandbox"
+    date: "2020-01-01T00:00:00Z"
+    issue: "https://github.com/cncf/toc/issues/1"
+repositories: "https://github.com/scalar-org/scalar-repo"
+`;
+    let result;
+    try {
+      result = parseDotProject('scalar-org', yamlText, 'test');
+    } catch (e) {
+      console.error(`  FAIL: threw on scalar repositories: ${e instanceof Error ? e.message : e}`);
+      process.exitCode = 1;
+      return;
+    }
+    assert(result !== null, '5a: scalar repositories parses (no throw)');
+    assert(result!.dot_project_repositories.length === 1, `5a: coerced scalar → 1 repo (got ${result!.dot_project_repositories.length})`);
+    assert(result!.dot_project_repositories[0].repo_owner === 'scalar-org', '5a: scalar repo owner parsed');
+    assert(result!.dot_project[0].repository_count === 1, '5a: repository_count = 1');
+    assert(result!.warnings.some(w => w.field === 'repositories'), '5a: emitted a repositories warning');
+  }
+
+  // 5b: repositories contains NON-STRING entries (number, null, object).
+  // Before the fix, `url.match` threw "url.match is not a function".
+  {
+    const yamlText = `
+schema_version: "1.0.0"
+slug: "mixed-repo"
+name: "Mixed Repo"
+repositories:
+  - "https://github.com/mixed-org/good-repo"
+  - 42
+  - null
+  - { nested: "object" }
+  - "https://github.com/mixed-org/second-repo"
+`;
+    let result;
+    try {
+      result = parseDotProject('mixed-org', yamlText, 'test');
+    } catch (e) {
+      console.error(`  FAIL: threw on non-string repo entries: ${e instanceof Error ? e.message : e}`);
+      process.exitCode = 1;
+      return;
+    }
+    assert(result !== null, '5b: mixed-type repositories parses (no throw)');
+    // Only the 2 valid string github URLs should survive.
+    assert(result!.dot_project_repositories.length === 2, `5b: kept 2 valid repos, skipped 3 junk (got ${result!.dot_project_repositories.length})`);
+    assert(result!.dot_project_repositories[0].repo_name === 'good-repo', '5b: first valid repo = good-repo');
+    assert(result!.dot_project_repositories[1].repo_name === 'second-repo', '5b: second valid repo = second-repo');
+    const repoWarnings = result!.warnings.filter(w => w.field === 'repositories');
+    assert(repoWarnings.length === 3, `5b: 3 skip warnings for non-string entries (got ${repoWarnings.length})`);
+  }
+
+  // 5c: project_lead as a NUMBER — must be skipped, not coerced to "42".
+  {
+    const yamlText = `
+schema_version: "1.0.0"
+slug: "numeric-lead"
+name: "Numeric Lead"
+project_lead: 42
+repositories:
+  - "https://github.com/nl-org/nl-repo"
+`;
+    const result = parseDotProject('nl-org', yamlText, 'test');
+    assert(result !== null, '5c: numeric project_lead parses');
+    assert(result!.dot_project[0].project_lead === null, `5c: numeric project_lead → null, NOT "42" (got ${JSON.stringify(result!.dot_project[0].project_lead)})`);
+    assert(result!.warnings.some(w => w.field === 'project_lead'), '5c: emitted project_lead warning');
+  }
+
+  // 5d: project_lead as MIXED list — keep strings, skip numbers.
+  {
+    const yamlText = `
+schema_version: "1.0.0"
+slug: "mixed-lead"
+name: "Mixed Lead"
+project_lead:
+  - "@alice"
+  - 99
+  - "bob"
+repositories:
+  - "https://github.com/ml-org/ml-repo"
+`;
+    const result = parseDotProject('ml-org', yamlText, 'test');
+    assert(result !== null, '5d: mixed project_lead parses');
+    assert(result!.dot_project[0].project_lead === 'alice, bob', `5d: kept alice,bob (@ stripped), skipped 99 (got ${JSON.stringify(result!.dot_project[0].project_lead)})`);
+  }
+
+  // 5e: maturity_log is a SCALAR (not a list) and audits contain junk.
+  {
+    const yamlText = `
+schema_version: "1.0.0"
+slug: "scalar-maturity"
+name: "Scalar Maturity"
+maturity_log: "not-a-list"
+audits:
+  - "junk-string"
+  - date: "2021-01-01T00:00:00Z"
+    type: "security"
+    url: "https://example.com/a"
+repositories:
+  - "https://github.com/sm-org/sm-repo"
+`;
+    let result;
+    try {
+      result = parseDotProject('sm-org', yamlText, 'test');
+    } catch (e) {
+      console.error(`  FAIL: threw on scalar maturity_log: ${e instanceof Error ? e.message : e}`);
+      process.exitCode = 1;
+      return;
+    }
+    assert(result !== null, '5e: scalar maturity_log + junk audits parses (no throw)');
+    // "not-a-list" coerced to 1-element array, then skipped (non-object) → 0 entries
+    assert(result!.dot_project_maturity_log.length === 0, `5e: non-object maturity entry skipped (got ${result!.dot_project_maturity_log.length})`);
+    assert(result!.dot_project_audits.length === 1, `5e: kept 1 valid audit, skipped junk (got ${result!.dot_project_audits.length})`);
+  }
+
+  // 5f: relative (non-github) repo URL — stored with null owner/name + warning.
+  {
+    const yamlText = `
+schema_version: "1.0.0"
+slug: "relative-repo"
+name: "Relative Repo"
+repositories:
+  - "SECURITY.md"
+  - "https://gitlab.com/foo/bar"
+`;
+    const result = parseDotProject('rel-org', yamlText, 'test');
+    assert(result !== null, '5f: relative/non-github URLs parse');
+    assert(result!.dot_project_repositories.length === 2, '5f: both non-github entries stored');
+    assert(result!.dot_project_repositories[0].repo_owner === null, '5f: relative URL → null owner');
+    assert(result!.dot_project_repositories[1].repo_owner === null, '5f: gitlab URL → null owner');
+    assert(result!.warnings.filter(w => w.field === 'repositories').length === 2, '5f: 2 non-github warnings');
+  }
+
+  // 5g: top-level YAML is a scalar/array, not a map → returns null (not a crash).
+  {
+    assert(parseDotProject('x', 'just a string', 'test') === null, '5g: scalar YAML → null');
+    assert(parseDotProject('x', '- a\n- b', 'test') === null, '5g: array YAML → null');
+    assert(parseDotProject('x', '', 'test') === null, '5g: empty YAML → null');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: maintainers.yaml parsing
+// ---------------------------------------------------------------------------
+
+function testMaintainers(): void {
+  console.log('\n══ Test 6: parseMaintainers ══\n');
+
+  const yamlText = `
+maintainers:
+  - project_id: "myproject"
+    org: "myorg"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - "@alice"
+          - "bob"
+          - 42
+      - name: "reviewers"
+        members:
+          - "carol"
+`;
+  const { maintainers, warnings } = parseMaintainers('myorg', yamlText);
+  console.log(JSON.stringify(maintainers, null, 2));
+  assert(maintainers.length === 3, `parsed 3 members (alice, bob, carol), skipped numeric (got ${maintainers.length})`);
+  assert(maintainers[0].member === 'alice', 'first member = alice (@ stripped)');
+  assert(maintainers[0].team === 'project-maintainers', 'team captured');
+  assert(maintainers[0].project_id === 'myproject', 'project_id captured');
+  assert(maintainers[0].maintainer_org === 'myorg', 'maintainer_org captured');
+  assert(warnings.some(w => w.field === 'maintainers.members'), 'emitted warning for numeric member');
+
+  // Malformed maintainers.yaml must not throw
+  let crashed = false;
+  try {
+    parseMaintainers('x', 'maintainers: "not-a-list"');
+    parseMaintainers('x', ': broken yaml [');
+    parseMaintainers('x', 'maintainers:\n  - teams: "not-a-list"');
+  } catch {
+    crashed = true;
+  }
+  assert(!crashed, 'malformed maintainers.yaml never throws');
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -243,6 +445,8 @@ async function main() {
   await testOpenTelemetry();
   testInvalidYaml();
   testMerge();
+  testMalformedEdgeCases();
+  testMaintainers();
 
   const exitCode = process.exitCode ?? 0;
   console.log(`\n${'='.repeat(50)}`);

--- a/src/ArtifactWriter.ts
+++ b/src/ArtifactWriter.ts
@@ -7,14 +7,21 @@ import chalk from 'chalk';
 import type { GetRepoDataArtifactsQuery, GetRepoDataExtendedInfoQuery } from './generated/graphql';
 import type { OrgRepo, ProjectMetadata, RepositoryTarget } from './config';
 import { installAndLoadExtensions } from './duckdb-extensions';
-import { 
-    normalizeGetRepoDataArtifacts, 
-    getNormalizationStats as getArtifactsStats 
+import {
+    normalizeGetRepoDataArtifacts,
+    getNormalizationStats as getArtifactsStats
 } from './normalizers/GetRepoDataArtifactsNormalizer';
-import { 
-    normalizeGetRepoDataExtendedInfo, 
-    getNormalizationStats as getExtendedStats 
+import {
+    normalizeGetRepoDataExtendedInfo,
+    getNormalizationStats as getExtendedStats
 } from './normalizers/GetRepoDataExtendedInfoNormalizer';
+import {
+    parseDotProject,
+    mergeDotProjectResults,
+    getDotProjectStats,
+    type DotProjectNormalized,
+} from './normalizers/DotProjectNormalizer';
+import type { GetDotProjectDataResponse } from './api';
 
 /**
  * Write artifacts to database and Parquet files
@@ -667,6 +674,169 @@ export async function writeOrgRepoArtifacts(
             con.closeSync();
         } catch (error) {
             console.warn('Warning: Could not properly close database connection:', error);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// .project data writer
+// ---------------------------------------------------------------------------
+
+/**
+ * DuckDB table schemas for empty .project tables.
+ * Mirrors the DotProjectNormalizer record shapes exactly.
+ */
+const DOT_PROJECT_TABLE_SCHEMAS = {
+    dot_project: `
+        org TEXT NOT NULL,
+        source_url TEXT NOT NULL,
+        schema_version TEXT,
+        slug TEXT,
+        name TEXT,
+        description TEXT,
+        type TEXT,
+        project_lead TEXT,
+        repository_count INTEGER,
+        website TEXT,
+        current_maturity TEXT,
+        current_maturity_date TEXT,
+        audit_count INTEGER,
+        security_policy_path TEXT,
+        security_threat_model_path TEXT,
+        security_contact_email TEXT,
+        security_advisory_url TEXT,
+        landscape_category TEXT,
+        landscape_subcategory TEXT,
+        package_managers_json TEXT,
+        fetched_at TIMESTAMP
+    `,
+    dot_project_repositories: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        repo_url TEXT NOT NULL,
+        repo_owner TEXT,
+        repo_name TEXT
+    `,
+    dot_project_maturity_log: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        phase TEXT,
+        date TEXT,
+        issue TEXT
+    `,
+    dot_project_audits: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        date TEXT,
+        type TEXT,
+        url TEXT
+    `,
+} as const;
+
+/**
+ * Processes GetDotProjectData GraphQL responses and writes four .project tables
+ * to an existing DuckDB database.  Follows the same temp-JSON + read_json()
+ * pattern used throughout ArtifactWriter.
+ *
+ * Tables written:
+ *   dot_project              — one row per org that has a .project repo
+ *   dot_project_repositories — one row per URL in repositories[]
+ *   dot_project_maturity_log — one row per maturity_log entry
+ *   dot_project_audits       — one row per audits[] entry
+ *
+ * Called from neo.ts after the main scan is complete (analogous to writeOrgRepoArtifacts).
+ *
+ * @param dotProjectResponses - Raw GraphQL responses from fetchDotProjectData (non-null only)
+ * @param outputDir           - Timestamped run directory that already contains database.db
+ */
+export async function writeDotProjectArtifacts(
+    dotProjectResponses: Array<{ org: string; data: GetDotProjectDataResponse }>,
+    outputDir: string
+): Promise<void> {
+    const dbPath = path.join(outputDir, 'database.db');
+    const db = await DuckDBInstance.create(dbPath);
+    const con = await db.connect();
+
+    try {
+        await installAndLoadExtensions(con);
+
+        console.log(chalk.cyan('\n📋 Processing .project data...'));
+
+        // Parse and normalize all responses
+        const parseResults = dotProjectResponses.map(({ org, data }) => {
+            const repo = data.repository;
+            if (!repo) return null;
+
+            const projectYamlBlob = repo.projectYaml;
+            if (
+                !projectYamlBlob ||
+                projectYamlBlob.__typename !== 'Blob' ||
+                !projectYamlBlob.text
+            ) {
+                // Repo exists but no project.yaml — unusual, skip
+                console.log(chalk.gray(`  ○ ${org}/.project: repo exists but no project.yaml`));
+                return null;
+            }
+
+            const sourceUrl = `https://github.com/${repo.nameWithOwner}/blob/HEAD/project.yaml`;
+            const result = parseDotProject(org, projectYamlBlob.text, sourceUrl);
+
+            if (!result) {
+                console.log(chalk.yellow(`  ⚠ ${org}/.project: project.yaml parse error`));
+                return null;
+            }
+
+            const maturity = result.dot_project[0]?.current_maturity ?? 'unknown';
+            console.log(chalk.green(`  ✓ ${org}/.project: ${maturity} (${result.dot_project_repositories.length} repos)`));
+            return result;
+        });
+
+        const normalized: DotProjectNormalized = mergeDotProjectResults(parseResults);
+        console.log(chalk.gray('\n' + getDotProjectStats(normalized)));
+
+        // Helper: write one table using temp-JSON + read_json() (or explicit schema if empty)
+        const writeTable = async (
+            tableName: keyof typeof DOT_PROJECT_TABLE_SCHEMAS,
+            data: unknown[]
+        ) => {
+            if (data.length > 0) {
+                const tempPath = path.join(outputDir, `temp_${tableName}.json`);
+                fs.writeFileSync(tempPath, JSON.stringify(data));
+                await con.run(`
+                    CREATE TABLE ${tableName} AS
+                    SELECT * FROM read_json('${tempPath}', format='array', auto_detect=true, union_by_name=true)
+                `);
+                fs.unlinkSync(tempPath);
+            } else {
+                await con.run(`CREATE TABLE ${tableName} (${DOT_PROJECT_TABLE_SCHEMAS[tableName]})`);
+            }
+            console.log(`  ✅ Created table: ${tableName} (${data.length} rows)`);
+        };
+
+        await writeTable('dot_project', normalized.dot_project);
+        await writeTable('dot_project_repositories', normalized.dot_project_repositories);
+        await writeTable('dot_project_maturity_log', normalized.dot_project_maturity_log);
+        await writeTable('dot_project_audits', normalized.dot_project_audits);
+
+        // Export new tables to Parquet (appends alongside existing parquet/ files)
+        const parquetDir = path.join(outputDir, 'parquet');
+        fs.mkdirSync(parquetDir, { recursive: true });
+
+        for (const tableName of Object.keys(DOT_PROJECT_TABLE_SCHEMAS) as Array<keyof typeof DOT_PROJECT_TABLE_SCHEMAS>) {
+            const parquetPath = path.join(parquetDir, `${tableName}.parquet`);
+            await con.run(`
+                COPY ${tableName} TO '${parquetPath}'
+                (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 100000)
+            `);
+        }
+        console.log(chalk.green('  ✓ Exported .project tables to Parquet'));
+
+        await con.run('CHECKPOINT');
+    } finally {
+        try {
+            con.closeSync();
+        } catch (error) {
+            console.warn('Warning: Could not properly close .project database connection:', error);
         }
     }
 }

--- a/src/ArtifactWriter.ts
+++ b/src/ArtifactWriter.ts
@@ -17,6 +17,7 @@ import {
 } from './normalizers/GetRepoDataExtendedInfoNormalizer';
 import {
     parseDotProject,
+    parseMaintainers,
     mergeDotProjectResults,
     getDotProjectStats,
     type DotProjectNormalized,
@@ -683,12 +684,19 @@ export async function writeOrgRepoArtifacts(
 // ---------------------------------------------------------------------------
 
 /**
- * DuckDB table schemas for empty .project tables.
- * Mirrors the DotProjectNormalizer record shapes exactly.
+ * DuckDB table schemas for the .project tables.
+ *
+ * These are ALWAYS applied (not just for empty tables): the table is created
+ * with the explicit schema first, then rows are INSERTed from JSON. This:
+ *   - enforces the PRIMARY KEY / column types regardless of data presence
+ *   - aligns date columns as TIMESTAMP (matching fetched_at), not TEXT
+ *   - guarantees a stable column order for downstream SQL models
+ *
+ * Column order here MUST match the SELECT projection used at insert time.
  */
 const DOT_PROJECT_TABLE_SCHEMAS = {
     dot_project: `
-        org TEXT NOT NULL,
+        org TEXT NOT NULL PRIMARY KEY,
         source_url TEXT NOT NULL,
         schema_version TEXT,
         slug TEXT,
@@ -699,7 +707,7 @@ const DOT_PROJECT_TABLE_SCHEMAS = {
         repository_count INTEGER,
         website TEXT,
         current_maturity TEXT,
-        current_maturity_date TEXT,
+        current_maturity_date TIMESTAMP,
         audit_count INTEGER,
         security_policy_path TEXT,
         security_threat_model_path TEXT,
@@ -715,36 +723,83 @@ const DOT_PROJECT_TABLE_SCHEMAS = {
         position INTEGER NOT NULL,
         repo_url TEXT NOT NULL,
         repo_owner TEXT,
-        repo_name TEXT
+        repo_name TEXT,
+        PRIMARY KEY (org, position)
     `,
     dot_project_maturity_log: `
         org TEXT NOT NULL,
         position INTEGER NOT NULL,
         phase TEXT,
-        date TEXT,
-        issue TEXT
+        date TIMESTAMP,
+        issue TEXT,
+        PRIMARY KEY (org, position)
     `,
     dot_project_audits: `
         org TEXT NOT NULL,
         position INTEGER NOT NULL,
-        date TEXT,
+        date TIMESTAMP,
         type TEXT,
-        url TEXT
+        url TEXT,
+        PRIMARY KEY (org, position)
+    `,
+    dot_project_maintainers: `
+        org TEXT NOT NULL,
+        project_id TEXT,
+        maintainer_org TEXT,
+        team TEXT,
+        member TEXT NOT NULL
     `,
 } as const;
 
 /**
- * Processes GetDotProjectData GraphQL responses and writes four .project tables
- * to an existing DuckDB database.  Follows the same temp-JSON + read_json()
- * pattern used throughout ArtifactWriter.
+ * Explicit column projections for each table's INSERT ... SELECT.
+ * Must match the column order in DOT_PROJECT_TABLE_SCHEMAS above.
+ * TIMESTAMP columns are cast from the JSON string via TRY_CAST so a malformed
+ * date lands as NULL rather than aborting the insert.
+ */
+const DOT_PROJECT_SELECT_COLUMNS: Record<keyof typeof DOT_PROJECT_TABLE_SCHEMAS, string> = {
+    dot_project: `
+        org, source_url, schema_version, slug, name, description, type,
+        project_lead, repository_count, website, current_maturity,
+        TRY_CAST(current_maturity_date AS TIMESTAMP) AS current_maturity_date,
+        audit_count, security_policy_path, security_threat_model_path,
+        security_contact_email, security_advisory_url, landscape_category,
+        landscape_subcategory, package_managers_json,
+        TRY_CAST(fetched_at AS TIMESTAMP) AS fetched_at
+    `,
+    dot_project_repositories: `
+        org, position, repo_url, repo_owner, repo_name
+    `,
+    dot_project_maturity_log: `
+        org, position, phase, TRY_CAST(date AS TIMESTAMP) AS date, issue
+    `,
+    dot_project_audits: `
+        org, position, TRY_CAST(date AS TIMESTAMP) AS date, type, url
+    `,
+    dot_project_maintainers: `
+        org, project_id, maintainer_org, team, member
+    `,
+};
+
+/**
+ * Processes GetDotProjectData GraphQL responses and writes five .project tables
+ * to an existing DuckDB database. Follows the same temp-JSON + read_json()
+ * pattern used throughout ArtifactWriter, but with explicit CREATE + INSERT so
+ * PRIMARY KEY and TIMESTAMP types are enforced.
  *
  * Tables written:
- *   dot_project              — one row per org that has a .project repo
- *   dot_project_repositories — one row per URL in repositories[]
- *   dot_project_maturity_log — one row per maturity_log entry
- *   dot_project_audits       — one row per audits[] entry
+ *   dot_project              — one row per org that has a .project repo (PK: org)
+ *   dot_project_repositories — one row per URL in repositories[] (PK: org,position)
+ *   dot_project_maturity_log — one row per maturity_log entry (PK: org,position)
+ *   dot_project_audits       — one row per audits[] entry (PK: org,position)
+ *   dot_project_maintainers  — one row per maintainer member (from maintainers.yaml)
  *
- * Called from neo.ts after the main scan is complete (analogous to writeOrgRepoArtifacts).
+ * ROBUSTNESS: a malformed project.yaml for ONE org must never abort the whole
+ * scan. Each org is parsed inside a try/catch; a failure logs + skips that org
+ * and continues. Schema violations that are tolerated (scalar-vs-array, bad
+ * types) are accumulated as warnings and summarized.
+ *
+ * Called from neo.ts after the main scan (analogous to writeOrgRepoArtifacts).
  *
  * @param dotProjectResponses - Raw GraphQL responses from fetchDotProjectData (non-null only)
  * @param outputDir           - Timestamped run directory that already contains database.db
@@ -762,53 +817,97 @@ export async function writeDotProjectArtifacts(
 
         console.log(chalk.cyan('\n📋 Processing .project data...'));
 
-        // Parse and normalize all responses
-        const parseResults = dotProjectResponses.map(({ org, data }) => {
-            const repo = data.repository;
-            if (!repo) return null;
+        // Parse and normalize all responses. Each org is isolated: a parse crash
+        // for one .project must NOT abort the scan of the other 249 orgs.
+        const parseResults: (DotProjectNormalized | null)[] = [];
+        for (const { org, data } of dotProjectResponses) {
+            try {
+                const repo = data.repository;
+                if (!repo) {
+                    parseResults.push(null);
+                    continue;
+                }
 
-            const projectYamlBlob = repo.projectYaml;
-            if (
-                !projectYamlBlob ||
-                projectYamlBlob.__typename !== 'Blob' ||
-                !projectYamlBlob.text
-            ) {
-                // Repo exists but no project.yaml — unusual, skip
-                console.log(chalk.gray(`  ○ ${org}/.project: repo exists but no project.yaml`));
-                return null;
+                const projectYamlBlob = repo.projectYaml;
+                if (
+                    !projectYamlBlob ||
+                    projectYamlBlob.__typename !== 'Blob' ||
+                    !projectYamlBlob.text
+                ) {
+                    console.log(chalk.gray(`  ○ ${org}/.project: repo exists but no project.yaml`));
+                    parseResults.push(null);
+                    continue;
+                }
+
+                // Provenance: use the resolved commit SHA if the query returned one
+                // (permalink), else fall back to the branch ref name, else HEAD.
+                const ref = repo.defaultBranchRef?.target?.oid
+                    ?? repo.defaultBranchRef?.name
+                    ?? 'HEAD';
+                const sourceUrl = `https://github.com/${repo.nameWithOwner}/blob/${ref}/project.yaml`;
+
+                const result = parseDotProject(org, projectYamlBlob.text, sourceUrl);
+                if (!result) {
+                    console.log(chalk.yellow(`  ⚠ ${org}/.project: project.yaml parse error (skipped, scan continues)`));
+                    parseResults.push(null);
+                    continue;
+                }
+
+                // Parse maintainers.yaml if present (also defensive)
+                const maintainersBlob = repo.maintainersYaml;
+                if (maintainersBlob && maintainersBlob.__typename === 'Blob' && maintainersBlob.text) {
+                    const { maintainers, warnings } = parseMaintainers(org, maintainersBlob.text);
+                    result.dot_project_maintainers.push(...maintainers);
+                    result.warnings.push(...warnings);
+                }
+
+                const maturity = result.dot_project[0]?.current_maturity ?? 'unknown';
+                console.log(chalk.green(
+                    `  ✓ ${org}/.project: ${maturity} ` +
+                    `(${result.dot_project_repositories.length} repos, ${result.dot_project_maintainers.length} maintainers)`
+                ));
+                parseResults.push(result);
+            } catch (err) {
+                // Belt-and-suspenders: parseDotProject is contractually no-throw,
+                // but anything unexpected here still must not kill the scan.
+                console.log(chalk.yellow(
+                    `  ⚠ ${org}/.project: unexpected error, skipped (scan continues): ` +
+                    `${err instanceof Error ? err.message : String(err)}`
+                ));
+                parseResults.push(null);
             }
-
-            const sourceUrl = `https://github.com/${repo.nameWithOwner}/blob/HEAD/project.yaml`;
-            const result = parseDotProject(org, projectYamlBlob.text, sourceUrl);
-
-            if (!result) {
-                console.log(chalk.yellow(`  ⚠ ${org}/.project: project.yaml parse error`));
-                return null;
-            }
-
-            const maturity = result.dot_project[0]?.current_maturity ?? 'unknown';
-            console.log(chalk.green(`  ✓ ${org}/.project: ${maturity} (${result.dot_project_repositories.length} repos)`));
-            return result;
-        });
+        }
 
         const normalized: DotProjectNormalized = mergeDotProjectResults(parseResults);
         console.log(chalk.gray('\n' + getDotProjectStats(normalized)));
 
-        // Helper: write one table using temp-JSON + read_json() (or explicit schema if empty)
+        // Surface a compact warning summary (grouped by field) without spamming.
+        if (normalized.warnings.length > 0) {
+            const byField = new Map<string, number>();
+            for (const w of normalized.warnings) {
+                byField.set(w.field, (byField.get(w.field) ?? 0) + 1);
+            }
+            const summary = Array.from(byField.entries())
+                .map(([field, n]) => `${field}: ${n}`)
+                .join(', ');
+            console.log(chalk.yellow(`  ⚠ Schema warnings (tolerated): ${summary}`));
+        }
+
+        // Write one table: explicit CREATE (with PK + types) then INSERT from JSON.
         const writeTable = async (
             tableName: keyof typeof DOT_PROJECT_TABLE_SCHEMAS,
             data: unknown[]
         ) => {
+            await con.run(`CREATE TABLE ${tableName} (${DOT_PROJECT_TABLE_SCHEMAS[tableName]})`);
             if (data.length > 0) {
                 const tempPath = path.join(outputDir, `temp_${tableName}.json`);
                 fs.writeFileSync(tempPath, JSON.stringify(data));
                 await con.run(`
-                    CREATE TABLE ${tableName} AS
-                    SELECT * FROM read_json('${tempPath}', format='array', auto_detect=true, union_by_name=true)
+                    INSERT INTO ${tableName}
+                    SELECT ${DOT_PROJECT_SELECT_COLUMNS[tableName]}
+                    FROM read_json('${tempPath}', format='array', auto_detect=true, union_by_name=true)
                 `);
                 fs.unlinkSync(tempPath);
-            } else {
-                await con.run(`CREATE TABLE ${tableName} (${DOT_PROJECT_TABLE_SCHEMAS[tableName]})`);
             }
             console.log(`  ✅ Created table: ${tableName} (${data.length} rows)`);
         };
@@ -817,6 +916,7 @@ export async function writeDotProjectArtifacts(
         await writeTable('dot_project_repositories', normalized.dot_project_repositories);
         await writeTable('dot_project_maturity_log', normalized.dot_project_maturity_log);
         await writeTable('dot_project_audits', normalized.dot_project_audits);
+        await writeTable('dot_project_maintainers', normalized.dot_project_maintainers);
 
         // Export new tables to Parquet (appends alongside existing parquet/ files)
         const parquetDir = path.join(outputDir, 'parquet');

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,6 +25,62 @@ import {
   GetOrgReposQuery,
 } from './generated/graphql';
 
+// ---------------------------------------------------------------------------
+// GetDotProjectData — inline query (avoids codegen dependency for new query)
+//
+// Fetches project.yaml (and maintainers.yaml) from the <org>/.project repo.
+// These are the canonical CNCF .project metadata files per the schema at:
+// ~/gh/f/cncf/automation/utilities/dot-project/SCHEMA.md
+//
+// Run `npm run codegen` to generate typed Document/Query for this if preferred.
+// ---------------------------------------------------------------------------
+const GET_DOT_PROJECT_DATA_QUERY = `
+  query GetDotProjectData($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      __typename
+      id
+      nameWithOwner
+      projectYaml: object(expression: "HEAD:project.yaml") {
+        ... on Blob {
+          __typename
+          id
+          text
+        }
+      }
+      maintainersYaml: object(expression: "HEAD:maintainers.yaml") {
+        ... on Blob {
+          __typename
+          id
+          text
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Shape of the GetDotProjectData response.
+ * Hand-typed here because we bypass the codegen for this query.
+ * Run `npm run codegen` to generate a proper typed document if desired.
+ */
+export interface GetDotProjectDataResponse {
+  repository: {
+    __typename: string;
+    id: string;
+    nameWithOwner: string;
+    projectYaml: {
+      __typename: string;
+      id: string;
+      text: string | null;
+    } | null;
+    maintainersYaml: {
+      __typename: string;
+      id: string;
+      text: string | null;
+    } | null;
+  } | null;
+}
+
 /**
  * Creates and configures a GraphQLClient for the GitHub API.
  * @param token - The GitHub Personal Access Token.
@@ -281,4 +337,81 @@ export async function fetchOrgRepos(
   }
 
   return { org, repos: allRepos, totalCount: allRepos.length };
+}
+
+// ---------------------------------------------------------------------------
+// .project data fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches project.yaml (and maintainers.yaml) from the <org>/.project repository.
+ *
+ * The .project repo is the canonical CNCF project metadata store. It lives at
+ * github.com/<org>/.project and contains project.yaml at the repo root.
+ * Many CNCF orgs don't have a .project repo yet — absent repos return null gracefully.
+ *
+ * Implementation note: uses the same GraphQL blob-fetch mechanism as
+ * GetRepoDataExtendedInfo (object(expression: "HEAD:...") { ... on Blob { text } }).
+ * The query is inlined rather than generated to avoid a codegen round-trip;
+ * run `npm run codegen` if you want a typed document node for this query.
+ *
+ * @param client  - GraphQL client (requires auth token)
+ * @param org     - GitHub organization login (e.g. "argoproj")
+ * @param verbose - Enable verbose logging
+ * @returns Parsed response, or null if the repo doesn't exist / fetch fails
+ */
+export async function fetchDotProjectData(
+  client: GraphQLClient,
+  org: string,
+  verbose: boolean
+): Promise<GetDotProjectDataResponse | null> {
+  const identifier = `${org}/.project`;
+
+  if (verbose) {
+    console.log(chalk.gray(`[API] Fetching .project for ${identifier}...`));
+  }
+
+  try {
+    const data = await client.request<GetDotProjectDataResponse>(
+      GET_DOT_PROJECT_DATA_QUERY,
+      { owner: org, name: '.project' }
+    );
+
+    if (data.repository === null) {
+      if (verbose) {
+        console.log(chalk.gray(`[API] ${identifier}: no .project repo (expected for most orgs)`));
+      }
+      return null;
+    }
+
+    if (verbose) {
+      const hasYaml = data.repository.projectYaml !== null;
+      console.log(chalk.green(`[API] ${identifier}: found (project.yaml: ${hasYaml ? 'yes' : 'no'})`));
+    }
+
+    return data;
+  } catch (error: unknown) {
+    // A NOT_FOUND error (repo doesn't exist) is expected and non-fatal.
+    // Any other error is logged but also returns null to keep the scan running.
+    if (error instanceof ClientError) {
+      const errors = error.response.errors ?? [];
+      const isNotFound = errors.some(
+        // GraphQLError has extensions.code or a raw `type` field depending on GitHub's error shape
+        (e: { type?: string; extensions?: { code?: string } }) =>
+          e.type === 'NOT_FOUND' || e.extensions?.code === 'NOT_FOUND'
+      );
+      if (isNotFound) {
+        if (verbose) {
+          console.log(chalk.gray(`[API] ${identifier}: NOT_FOUND (no .project repo)`));
+        }
+        return null;
+      }
+
+      // Log non-404 errors at warn level (don't fail the scan)
+      console.warn(chalk.yellow(`[API] ${identifier}: GraphQL error`), JSON.stringify(errors));
+    } else if (error instanceof Error) {
+      console.warn(chalk.yellow(`[API] ${identifier}: ${error.message}`));
+    }
+    return null;
+  }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -40,6 +40,14 @@ const GET_DOT_PROJECT_DATA_QUERY = `
       __typename
       id
       nameWithOwner
+      defaultBranchRef {
+        name
+        target {
+          ... on Commit {
+            oid
+          }
+        }
+      }
       projectYaml: object(expression: "HEAD:project.yaml") {
         ... on Blob {
           __typename
@@ -68,6 +76,14 @@ export interface GetDotProjectDataResponse {
     __typename: string;
     id: string;
     nameWithOwner: string;
+    /** Default branch ref — used to resolve a permalink commit SHA for provenance. */
+    defaultBranchRef: {
+      name: string;
+      target: {
+        // Commit selection returns oid; other target types return {} here.
+        oid?: string;
+      } | null;
+    } | null;
     projectYaml: {
       __typename: string;
       id: string;

--- a/src/graphql/GetDotProjectData.graphql
+++ b/src/graphql/GetDotProjectData.graphql
@@ -3,6 +3,14 @@ query GetDotProjectData($owner: String!, $name: String!) {
     __typename
     id
     nameWithOwner
+    defaultBranchRef {
+      name
+      target {
+        ... on Commit {
+          oid
+        }
+      }
+    }
     projectYaml: object(expression: "HEAD:project.yaml") {
       ... on Blob {
         __typename

--- a/src/graphql/GetDotProjectData.graphql
+++ b/src/graphql/GetDotProjectData.graphql
@@ -1,0 +1,21 @@
+query GetDotProjectData($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    __typename
+    id
+    nameWithOwner
+    projectYaml: object(expression: "HEAD:project.yaml") {
+      ... on Blob {
+        __typename
+        id
+        text
+      }
+    }
+    maintainersYaml: object(expression: "HEAD:maintainers.yaml") {
+      ... on Blob {
+        __typename
+        id
+        text
+      }
+    }
+  }
+}

--- a/src/neo.ts
+++ b/src/neo.ts
@@ -249,37 +249,80 @@ async function main() {
     console.log(chalk.yellow('\n⚠  No data collected for any query, skipping database creation'));
   }
 
-  // .project metadata: fetch project.yaml from <org>/.project for each unique org
+  // .project metadata: fetch project.yaml from <org>/.project.
+  //
+  // The canonical .project repo lives in the org of a project's PRIMARY repo.
+  // We probe, in priority order:
+  //   1. each project's primary-repo org (the canonical .project location)
+  //   2. all other repo-owner orgs (covers multi-org projects / non-primary orgs)
+  // Ordering primary orgs first means the canonical org is probed even for
+  // projects whose non-primary repos live under different/legacy orgs.
   if (fetchDotProject && allResponses.length > 0) {
     console.log(chalk.gray('\n' + '─'.repeat(50)));
     console.log(chalk.bold.cyan('\n📋 Fetching .project metadata...\n'));
 
-    // Collect unique orgs from the scanned repos
-    const dotProjectOrgSet = new Set<string>();
-    for (const item of normalizedInput) {
-      dotProjectOrgSet.add(item.repo.owner);
-    }
-    const uniqueOrgs = Array.from(dotProjectOrgSet);
-    console.log(chalk.cyan(`  Unique orgs to probe: ${uniqueOrgs.length}`));
+    // Build an ordered, de-duplicated org list: canonical (primary) orgs first.
+    const seenOrgs = new Set<string>();
+    const orderedOrgs: string[] = [];
+    const addOrg = (org: string) => {
+      if (!org || seenOrgs.has(org)) return;
+      seenOrgs.add(org);
+      orderedOrgs.push(org);
+    };
 
-    // Fetch <org>/.project for each unique org (sequential to be polite)
+    // Pass 1: canonical .project org = org of each project's primary repo.
+    // rawInput carries the rich ProjectMetadata (with the `primary` flag);
+    // normalizedInput has already been flattened and lost per-project grouping.
+    for (const item of rawInput) {
+      if ('repos' in item && Array.isArray((item as ProjectMetadata).repos)) {
+        const project = item as ProjectMetadata;
+        const primary = project.repos.find(r => r.primary) ?? project.repos[0];
+        if (primary) addOrg(primary.owner);
+      }
+    }
+    // Pass 2: all remaining orgs from the scanned repos (fallback coverage).
+    for (const item of normalizedInput) {
+      addOrg(item.repo.owner);
+    }
+
+    console.log(chalk.cyan(`  Unique orgs to probe: ${orderedOrgs.length} (canonical/primary orgs first)`));
+
+    // Fetch <org>/.project in small batches with an inter-batch delay,
+    // mirroring build-repo-list.ts (BATCH_SIZE=8, BATCH_DELAY_MS=600) to avoid
+    // hammering the GraphQL API across a ~250-org sweep.
     const dotProjectResults: Array<{ org: string; data: import('./api').GetDotProjectDataResponse }> = [];
     let dotProjectFound = 0;
     let dotProjectMissing = 0;
 
-    for (const org of uniqueOrgs) {
-      const data = await fetchDotProjectData(client, org, verbose);
-      if (data && data.repository !== null) {
-        dotProjectResults.push({ org, data });
-        dotProjectFound++;
-        if (!verbose) {
-          console.log(chalk.green(`  ✓ ${org}/.project`));
+    const DP_BATCH_SIZE = 8;
+    const DP_BATCH_DELAY_MS = 600;
+
+    for (let i = 0; i < orderedOrgs.length; i += DP_BATCH_SIZE) {
+      const batch = orderedOrgs.slice(i, i + DP_BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map(async (org) => {
+          const data = await fetchDotProjectData(client, org, verbose);
+          return { org, data };
+        })
+      );
+
+      for (const { org, data } of batchResults) {
+        if (data && data.repository !== null) {
+          dotProjectResults.push({ org, data });
+          dotProjectFound++;
+          if (!verbose) {
+            console.log(chalk.green(`  ✓ ${org}/.project`));
+          }
+        } else {
+          dotProjectMissing++;
+          if (verbose) {
+            console.log(chalk.gray(`  ○ ${org}/.project: not found (skipped)`));
+          }
         }
-      } else {
-        dotProjectMissing++;
-        if (verbose) {
-          console.log(chalk.gray(`  ○ ${org}/.project: not found (skipped)`));
-        }
+      }
+
+      if (i + DP_BATCH_SIZE < orderedOrgs.length) {
+        await new Promise(resolve => setTimeout(resolve, DP_BATCH_DELAY_MS));
       }
     }
 

--- a/src/neo.ts
+++ b/src/neo.ts
@@ -6,9 +6,9 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { createApiClient, fetchRepositoryArtifacts, fetchRepositoryExtendedInfo, fetchOrgRepos } from './api';
+import { createApiClient, fetchRepositoryArtifacts, fetchRepositoryExtendedInfo, fetchOrgRepos, fetchDotProjectData } from './api';
 import { appendRawResponse } from './rawResponseWriter';
-import { writeArtifacts, writeOrgRepoArtifacts } from './ArtifactWriter';
+import { writeArtifacts, writeOrgRepoArtifacts, writeDotProjectArtifacts } from './ArtifactWriter';
 import type { RepositoryTarget, ProjectMetadata } from './config';
 import { normalizeGetOrgRepos, getOrgReposNormalizationStats } from './normalizers/GetOrgReposNormalizer';
 import { SecurityAnalyzer } from './SecurityAnalyzer';
@@ -83,6 +83,7 @@ async function main() {
     .option('--analyze', 'Run security analysis after data collection', false)
     .option('--persist-files', 'Persist downloaded files (SECURITY.md, security-insights.yml) to disk', true)
     .option('--scan-orgs', 'Scan all GitHub orgs found in input data for repo discovery', false)
+    .option('--dot-project', 'Fetch .project metadata (project.yaml) for each org via GraphQL and write to DuckDB', false)
     .option('-v, --verbose', 'Verbose output', false)
     .parse(process.argv);
 
@@ -97,6 +98,7 @@ async function main() {
     analyze: runAnalysis,
     persistFiles,
     scanOrgs,
+    dotProject: fetchDotProject,
     verbose
   } = options;
 
@@ -245,6 +247,55 @@ async function main() {
     }
   } else {
     console.log(chalk.yellow('\n⚠  No data collected for any query, skipping database creation'));
+  }
+
+  // .project metadata: fetch project.yaml from <org>/.project for each unique org
+  if (fetchDotProject && allResponses.length > 0) {
+    console.log(chalk.gray('\n' + '─'.repeat(50)));
+    console.log(chalk.bold.cyan('\n📋 Fetching .project metadata...\n'));
+
+    // Collect unique orgs from the scanned repos
+    const dotProjectOrgSet = new Set<string>();
+    for (const item of normalizedInput) {
+      dotProjectOrgSet.add(item.repo.owner);
+    }
+    const uniqueOrgs = Array.from(dotProjectOrgSet);
+    console.log(chalk.cyan(`  Unique orgs to probe: ${uniqueOrgs.length}`));
+
+    // Fetch <org>/.project for each unique org (sequential to be polite)
+    const dotProjectResults: Array<{ org: string; data: import('./api').GetDotProjectDataResponse }> = [];
+    let dotProjectFound = 0;
+    let dotProjectMissing = 0;
+
+    for (const org of uniqueOrgs) {
+      const data = await fetchDotProjectData(client, org, verbose);
+      if (data && data.repository !== null) {
+        dotProjectResults.push({ org, data });
+        dotProjectFound++;
+        if (!verbose) {
+          console.log(chalk.green(`  ✓ ${org}/.project`));
+        }
+      } else {
+        dotProjectMissing++;
+        if (verbose) {
+          console.log(chalk.gray(`  ○ ${org}/.project: not found (skipped)`));
+        }
+      }
+    }
+
+    console.log(chalk.gray(`\n  Found: ${dotProjectFound}, Missing/skipped: ${dotProjectMissing}`));
+
+    if (dotProjectResults.length > 0) {
+      try {
+        await writeDotProjectArtifacts(dotProjectResults, timestampedDir);
+        console.log(chalk.green('  ✓ .project tables written to database'));
+      } catch (error) {
+        console.error(chalk.red('\n❌ .project write failed:'), error);
+        throw error;
+      }
+    } else {
+      console.log(chalk.yellow('  ⚠ No .project repos found for any org in this scan'));
+    }
   }
 
   // Org-level scanning: discover all repos across orgs present in the input data

--- a/src/normalizers/DotProjectNormalizer.ts
+++ b/src/normalizers/DotProjectNormalizer.ts
@@ -1,0 +1,316 @@
+/**
+ * DotProjectNormalizer.ts
+ *
+ * Parses fetched project.yaml text (from the <org>/.project repository) and
+ * normalizes it into flat relational records suitable for DuckDB insert.
+ *
+ * Schema source: ~/gh/f/cncf/automation/utilities/dot-project/SCHEMA.md
+ *
+ * Tables produced:
+ *   dot_project              — one row per project org (top-level fields)
+ *   dot_project_repositories — one row per URL in repositories[]
+ *   dot_project_maturity_log — one row per maturity_log entry
+ *   dot_project_audits       — one row per audits[] entry
+ */
+
+import * as yaml from 'yaml';
+
+// ---------------------------------------------------------------------------
+// Raw .project YAML shape (what we care about)
+// ---------------------------------------------------------------------------
+
+export interface DotProjectYaml {
+  schema_version?: string;
+  slug?: string;
+  name?: string;
+  description?: string;
+  type?: string;
+  project_lead?: string | string[];
+  repositories?: string[];
+  website?: string;
+  maturity_log?: Array<{
+    phase?: string;
+    date?: string | Date;
+    issue?: string;
+  }>;
+  audits?: Array<{
+    date?: string | Date;
+    type?: string;
+    url?: string;
+  }>;
+  security?: {
+    policy?: { path?: string };
+    threat_model?: { path?: string };
+    contact?: {
+      email?: string;
+      advisory_url?: string;
+    };
+  };
+  package_managers?: Record<string, string | string[]>;
+  landscape?: {
+    category?: string;
+    subcategory?: string;
+  };
+  // We capture but don't deep-expand governance / legal / documentation
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Normalized record types (DuckDB row shapes)
+// ---------------------------------------------------------------------------
+
+export interface DotProjectRecord {
+  /** Synthetic primary key: the GitHub org login */
+  org: string;
+  /** Source URL: https://github.com/<org>/.project/blob/HEAD/project.yaml */
+  source_url: string;
+  schema_version: string | null;
+  slug: string | null;
+  name: string | null;
+  description: string | null;
+  type: string | null;
+  /**
+   * project_lead serialized as a comma-separated string
+   * (handles both string and string[] schema variants)
+   */
+  project_lead: string | null;
+  repository_count: number;
+  website: string | null;
+  /** Current/latest maturity phase (last entry in maturity_log) */
+  current_maturity: string | null;
+  /** Date of current/latest maturity phase transition */
+  current_maturity_date: string | null;
+  audit_count: number;
+  /** Security policy path */
+  security_policy_path: string | null;
+  /** Threat model path */
+  security_threat_model_path: string | null;
+  /** Security contact email */
+  security_contact_email: string | null;
+  /** Security advisory URL */
+  security_advisory_url: string | null;
+  /** Landscape category */
+  landscape_category: string | null;
+  /** Landscape subcategory */
+  landscape_subcategory: string | null;
+  /** package_managers serialized as JSON string */
+  package_managers_json: string | null;
+  fetched_at: string;
+}
+
+export interface DotProjectRepository {
+  /** FK → dot_project.org */
+  org: string;
+  /** Ordinal position in repositories[] (0-indexed) */
+  position: number;
+  /** Raw URL from repositories[] */
+  repo_url: string;
+  /** Parsed GitHub owner (null if not a github.com URL) */
+  repo_owner: string | null;
+  /** Parsed GitHub repo name (null if not a github.com URL) */
+  repo_name: string | null;
+}
+
+export interface DotProjectMaturityEntry {
+  /** FK → dot_project.org */
+  org: string;
+  /** Ordinal position in maturity_log[] (0-indexed, chronological) */
+  position: number;
+  phase: string | null;
+  date: string | null;
+  issue: string | null;
+}
+
+export interface DotProjectAudit {
+  /** FK → dot_project.org */
+  org: string;
+  /** Ordinal position in audits[] (0-indexed) */
+  position: number;
+  date: string | null;
+  type: string | null;
+  url: string | null;
+}
+
+export interface DotProjectNormalized {
+  dot_project: DotProjectRecord[];
+  dot_project_repositories: DotProjectRepository[];
+  dot_project_maturity_log: DotProjectMaturityEntry[];
+  dot_project_audits: DotProjectAudit[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a github.com URL and return { owner, name } or null.
+ * Handles https://github.com/org/repo and https://github.com/org/repo.git
+ */
+function parseGithubUrl(url: string): { owner: string; name: string } | null {
+  const match = url.match(/github\.com\/([^/]+)\/([^/#? ]+)/);
+  if (!match) return null;
+  return {
+    owner: match[1],
+    name: match[2].replace(/\.git$/, ''),
+  };
+}
+
+/** Coerce a date value (string or Date) to ISO string or null */
+function toIsoString(val: string | Date | null | undefined): string | null {
+  if (!val) return null;
+  if (val instanceof Date) return val.toISOString();
+  return String(val);
+}
+
+/** Coerce project_lead (string | string[]) to a comma-separated string */
+function serializeProjectLead(lead: string | string[] | null | undefined): string | null {
+  if (!lead) return null;
+  if (Array.isArray(lead)) {
+    const flat = lead.map(s => String(s).trim()).filter(Boolean);
+    return flat.length > 0 ? flat.join(', ') : null;
+  }
+  const s = String(lead).trim();
+  return s || null;
+}
+
+// ---------------------------------------------------------------------------
+// Core parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single project.yaml text blob fetched from <org>/.project
+ * and return normalized records.
+ *
+ * @param org - GitHub org login (used as FK / PK)
+ * @param projectYamlText - Raw YAML text of project.yaml
+ * @param sourceUrl - Canonical source URL for provenance
+ * @returns Normalized records, or null if YAML is invalid / empty
+ */
+export function parseDotProject(
+  org: string,
+  projectYamlText: string,
+  sourceUrl: string
+): DotProjectNormalized | null {
+  let parsed: DotProjectYaml;
+  try {
+    parsed = yaml.parse(projectYamlText) as DotProjectYaml;
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const now = new Date().toISOString();
+
+  // ── maturity_log ──────────────────────────────────────────────────────────
+  const maturityLog = parsed.maturity_log ?? [];
+  const maturityEntries: DotProjectMaturityEntry[] = maturityLog.map((entry, i) => ({
+    org,
+    position: i,
+    phase: entry.phase ?? null,
+    date: toIsoString(entry.date),
+    issue: entry.issue ?? null,
+  }));
+
+  // Current maturity = last chronological entry
+  const lastMaturity = maturityLog.length > 0 ? maturityLog[maturityLog.length - 1] : null;
+
+  // ── audits ────────────────────────────────────────────────────────────────
+  const rawAudits = parsed.audits ?? [];
+  const auditEntries: DotProjectAudit[] = rawAudits.map((audit, i) => ({
+    org,
+    position: i,
+    date: toIsoString(audit.date),
+    type: audit.type ?? null,
+    url: audit.url ?? null,
+  }));
+
+  // ── repositories ──────────────────────────────────────────────────────────
+  const rawRepos = parsed.repositories ?? [];
+  const repoEntries: DotProjectRepository[] = rawRepos.map((url, i) => {
+    const gh = parseGithubUrl(url);
+    return {
+      org,
+      position: i,
+      repo_url: url,
+      repo_owner: gh?.owner ?? null,
+      repo_name: gh?.name ?? null,
+    };
+  });
+
+  // ── package_managers ──────────────────────────────────────────────────────
+  let packageManagersJson: string | null = null;
+  if (parsed.package_managers && typeof parsed.package_managers === 'object') {
+    try {
+      packageManagersJson = JSON.stringify(parsed.package_managers);
+    } catch {
+      packageManagersJson = null;
+    }
+  }
+
+  // ── top-level record ──────────────────────────────────────────────────────
+  const record: DotProjectRecord = {
+    org,
+    source_url: sourceUrl,
+    schema_version: parsed.schema_version ?? null,
+    slug: parsed.slug ?? null,
+    name: parsed.name ?? null,
+    description: parsed.description ?? null,
+    type: parsed.type ?? null,
+    project_lead: serializeProjectLead(parsed.project_lead),
+    repository_count: rawRepos.length,
+    website: parsed.website ?? null,
+    current_maturity: lastMaturity?.phase ?? null,
+    current_maturity_date: toIsoString(lastMaturity?.date),
+    audit_count: rawAudits.length,
+    security_policy_path: parsed.security?.policy?.path ?? null,
+    security_threat_model_path: parsed.security?.threat_model?.path ?? null,
+    security_contact_email: parsed.security?.contact?.email ?? null,
+    security_advisory_url: parsed.security?.contact?.advisory_url ?? null,
+    landscape_category: parsed.landscape?.category ?? null,
+    landscape_subcategory: parsed.landscape?.subcategory ?? null,
+    package_managers_json: packageManagersJson,
+    fetched_at: now,
+  };
+
+  return {
+    dot_project: [record],
+    dot_project_repositories: repoEntries,
+    dot_project_maturity_log: maturityEntries,
+    dot_project_audits: auditEntries,
+  };
+}
+
+/**
+ * Merge multiple parseDotProject results into a single DotProjectNormalized.
+ * Skips any null results (parse errors / missing repos).
+ */
+export function mergeDotProjectResults(
+  results: (DotProjectNormalized | null)[]
+): DotProjectNormalized {
+  const merged: DotProjectNormalized = {
+    dot_project: [],
+    dot_project_repositories: [],
+    dot_project_maturity_log: [],
+    dot_project_audits: [],
+  };
+
+  for (const r of results) {
+    if (!r) continue;
+    merged.dot_project.push(...r.dot_project);
+    merged.dot_project_repositories.push(...r.dot_project_repositories);
+    merged.dot_project_maturity_log.push(...r.dot_project_maturity_log);
+    merged.dot_project_audits.push(...r.dot_project_audits);
+  }
+
+  return merged;
+}
+
+export function getDotProjectStats(normalized: DotProjectNormalized): string {
+  return [
+    `Normalized ${normalized.dot_project.length} .project records`,
+    `  ${normalized.dot_project_repositories.length} repositories`,
+    `  ${normalized.dot_project_maturity_log.length} maturity_log entries`,
+    `  ${normalized.dot_project_audits.length} audits`,
+  ].join('\n');
+}

--- a/src/normalizers/DotProjectNormalizer.ts
+++ b/src/normalizers/DotProjectNormalizer.ts
@@ -19,39 +19,32 @@ import * as yaml from 'yaml';
 // Raw .project YAML shape (what we care about)
 // ---------------------------------------------------------------------------
 
+// NOTE: These types describe the *expected* shape. Because .project files are
+// hand-edited and often violate the schema, the parser treats every field as
+// untrusted (uses `unknown`-safe accessors) and never assumes an array/object
+// is actually an array/object. The optional fields below are documentation of
+// intent, not a runtime guarantee.
 export interface DotProjectYaml {
-  schema_version?: string;
-  slug?: string;
-  name?: string;
-  description?: string;
-  type?: string;
-  project_lead?: string | string[];
-  repositories?: string[];
-  website?: string;
-  maturity_log?: Array<{
-    phase?: string;
-    date?: string | Date;
-    issue?: string;
-  }>;
-  audits?: Array<{
-    date?: string | Date;
-    type?: string;
-    url?: string;
-  }>;
-  security?: {
-    policy?: { path?: string };
-    threat_model?: { path?: string };
-    contact?: {
-      email?: string;
-      advisory_url?: string;
-    };
-  };
-  package_managers?: Record<string, string | string[]>;
-  landscape?: {
-    category?: string;
-    subcategory?: string;
-  };
+  schema_version?: unknown;
+  slug?: unknown;
+  name?: unknown;
+  description?: unknown;
+  type?: unknown;
+  project_lead?: unknown;
+  repositories?: unknown;
+  website?: unknown;
+  maturity_log?: unknown;
+  audits?: unknown;
+  security?: unknown;
+  package_managers?: unknown;
+  landscape?: unknown;
   // We capture but don't deep-expand governance / legal / documentation
+  [key: string]: unknown;
+}
+
+/** Expected shape of maintainers.yaml (also treated as untrusted at runtime). */
+export interface MaintainersYaml {
+  maintainers?: unknown;
   [key: string]: unknown;
 }
 
@@ -131,22 +124,51 @@ export interface DotProjectAudit {
   url: string | null;
 }
 
+export interface DotProjectMaintainer {
+  /** FK → dot_project.org */
+  org: string;
+  /** project_id from maintainers.yaml (should match slug in project.yaml) */
+  project_id: string | null;
+  /** GitHub org from the maintainer entry (may differ from probe org) */
+  maintainer_org: string | null;
+  /** Team name (e.g. project-maintainers) */
+  team: string | null;
+  /** GitHub handle (normalized: trimmed, leading @ stripped) */
+  member: string;
+}
+
 export interface DotProjectNormalized {
   dot_project: DotProjectRecord[];
   dot_project_repositories: DotProjectRepository[];
   dot_project_maturity_log: DotProjectMaturityEntry[];
   dot_project_audits: DotProjectAudit[];
+  dot_project_maintainers: DotProjectMaintainer[];
+  /** Non-fatal schema violations encountered while parsing (for logging) */
+  warnings: DotProjectWarning[];
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — all defensive: real .project files in the wild are hand-edited and
+// frequently violate the schema. Never throw; coerce/skip and keep going.
 // ---------------------------------------------------------------------------
+
+/**
+ * A warning accumulated during parsing (schema violations that we tolerate).
+ * Surfaced to the caller for logging, but does not abort the parse.
+ */
+export interface DotProjectWarning {
+  org: string;
+  field: string;
+  message: string;
+}
 
 /**
  * Parse a github.com URL and return { owner, name } or null.
  * Handles https://github.com/org/repo and https://github.com/org/repo.git
+ * Returns null for non-string input or non-github URLs (e.g. relative paths).
  */
-function parseGithubUrl(url: string): { owner: string; name: string } | null {
+function parseGithubUrl(url: unknown): { owner: string; name: string } | null {
+  if (typeof url !== 'string') return null;
   const match = url.match(/github\.com\/([^/]+)\/([^/#? ]+)/);
   if (!match) return null;
   return {
@@ -155,22 +177,89 @@ function parseGithubUrl(url: string): { owner: string; name: string } | null {
   };
 }
 
-/** Coerce a date value (string or Date) to ISO string or null */
-function toIsoString(val: string | Date | null | undefined): string | null {
-  if (!val) return null;
-  if (val instanceof Date) return val.toISOString();
-  return String(val);
+/**
+ * Coerce a YAML value into an array of items.
+ * - already an array → returned as-is
+ * - a single scalar (string/object) → wrapped in a one-element array
+ * - null/undefined → empty array
+ * This absorbs the common schema violation where a field that should be a
+ * sequence is written as a single scalar (e.g. `repositories: "https://..."`).
+ */
+function coerceToArray<T>(val: T | T[] | null | undefined): T[] {
+  if (val === null || val === undefined) return [];
+  return Array.isArray(val) ? val : [val];
 }
 
-/** Coerce project_lead (string | string[]) to a comma-separated string */
-function serializeProjectLead(lead: string | string[] | null | undefined): string | null {
-  if (!lead) return null;
-  if (Array.isArray(lead)) {
-    const flat = lead.map(s => String(s).trim()).filter(Boolean);
-    return flat.length > 0 ? flat.join(', ') : null;
+/** Coerce a date value (string or Date) to ISO string or null. Never throws. */
+function toIsoString(val: unknown): string | null {
+  if (val === null || val === undefined) return null;
+  if (val instanceof Date) {
+    const t = val.getTime();
+    return Number.isNaN(t) ? null : val.toISOString();
   }
-  const s = String(lead).trim();
+  if (typeof val === 'string') {
+    const s = val.trim();
+    return s || null;
+  }
+  // Numbers / booleans / objects are not valid dates — drop rather than coerce.
+  return null;
+}
+
+/**
+ * Serialize project_lead. Per schema it is a GitHub handle or `org/team-name`,
+ * as a single string or a list of strings. Non-string entries (numbers, nulls,
+ * objects) are INVALID data — they are skipped with a warning, not coerced to
+ * "42" (which would be wrong data landing in the DB).
+ *
+ * @returns the serialized value plus any warnings for skipped entries
+ */
+function serializeProjectLead(
+  org: string,
+  lead: unknown
+): { value: string | null; warnings: DotProjectWarning[] } {
+  const warnings: DotProjectWarning[] = [];
+  if (lead === null || lead === undefined) return { value: null, warnings };
+
+  const rawItems = Array.isArray(lead) ? lead : [lead];
+  const valid: string[] = [];
+
+  for (const item of rawItems) {
+    if (typeof item === 'string') {
+      // Strip a leading @ per schema handle-normalization rules.
+      const s = item.trim().replace(/^@/, '');
+      if (s) valid.push(s);
+    } else {
+      warnings.push({
+        org,
+        field: 'project_lead',
+        message: `skipped non-string entry (${typeof item}: ${JSON.stringify(item)})`,
+      });
+    }
+  }
+
+  return { value: valid.length > 0 ? valid.join(', ') : null, warnings };
+}
+
+/** Coerce a value to a trimmed non-empty string, or null. Never throws. */
+function toStringOrNull(val: unknown): string | null {
+  if (typeof val !== 'string') return null;
+  const s = val.trim();
   return s || null;
+}
+
+/** True if val is a non-null, non-array plain object. */
+function isObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val);
+}
+
+/** Safe nested string accessor: obj.a.b as a string, else null. Never throws. */
+function nestedString(root: unknown, ...keys: string[]): string | null {
+  let cur: unknown = root;
+  for (const k of keys) {
+    if (!isObject(cur)) return null;
+    cur = cur[k];
+  }
+  return toStringOrNull(cur);
 }
 
 // ---------------------------------------------------------------------------
@@ -181,94 +270,145 @@ function serializeProjectLead(lead: string | string[] | null | undefined): strin
  * Parse a single project.yaml text blob fetched from <org>/.project
  * and return normalized records.
  *
+ * DEFENSIVE CONTRACT: this function NEVER throws. Real-world .project files are
+ * hand-edited and routinely violate the schema (scalar where a list is expected,
+ * non-string entries, wrong types). All such cases are coerced or skipped with a
+ * warning; one malformed file must never abort a 250-org scan.
+ *
  * @param org - GitHub org login (used as FK / PK)
  * @param projectYamlText - Raw YAML text of project.yaml
- * @param sourceUrl - Canonical source URL for provenance
- * @returns Normalized records, or null if YAML is invalid / empty
+ * @param sourceUrl - Canonical source URL for provenance (permalink if resolvable)
+ * @returns Normalized records, or null if YAML is invalid / empty / not an object
  */
 export function parseDotProject(
   org: string,
   projectYamlText: string,
   sourceUrl: string
 ): DotProjectNormalized | null {
-  let parsed: DotProjectYaml;
+  let parsed: unknown;
   try {
-    parsed = yaml.parse(projectYamlText) as DotProjectYaml;
+    parsed = yaml.parse(projectYamlText);
   } catch {
     return null;
   }
 
-  if (!parsed || typeof parsed !== 'object') return null;
+  if (!isObject(parsed)) return null;
 
+  const p = parsed as DotProjectYaml;
+  const warnings: DotProjectWarning[] = [];
   const now = new Date().toISOString();
 
   // ── maturity_log ──────────────────────────────────────────────────────────
-  const maturityLog = parsed.maturity_log ?? [];
-  const maturityEntries: DotProjectMaturityEntry[] = maturityLog.map((entry, i) => ({
-    org,
-    position: i,
-    phase: entry.phase ?? null,
-    date: toIsoString(entry.date),
-    issue: entry.issue ?? null,
-  }));
-
-  // Current maturity = last chronological entry
-  const lastMaturity = maturityLog.length > 0 ? maturityLog[maturityLog.length - 1] : null;
+  // Guard scalar-vs-array; skip non-object entries defensively.
+  const rawMaturity = coerceToArray(p.maturity_log);
+  if (p.maturity_log !== undefined && !Array.isArray(p.maturity_log)) {
+    warnings.push({ org, field: 'maturity_log', message: 'expected a list; coerced single value to a 1-element list' });
+  }
+  const maturityEntries: DotProjectMaturityEntry[] = [];
+  rawMaturity.forEach((entry, i) => {
+    if (!isObject(entry)) {
+      warnings.push({ org, field: 'maturity_log', message: `skipped non-object entry at index ${i}` });
+      return;
+    }
+    maturityEntries.push({
+      org,
+      position: maturityEntries.length,
+      phase: toStringOrNull(entry.phase),
+      date: toIsoString(entry.date),
+      issue: toStringOrNull(entry.issue),
+    });
+  });
+  const lastMaturity = maturityEntries.length > 0 ? maturityEntries[maturityEntries.length - 1] : null;
 
   // ── audits ────────────────────────────────────────────────────────────────
-  const rawAudits = parsed.audits ?? [];
-  const auditEntries: DotProjectAudit[] = rawAudits.map((audit, i) => ({
-    org,
-    position: i,
-    date: toIsoString(audit.date),
-    type: audit.type ?? null,
-    url: audit.url ?? null,
-  }));
+  const rawAudits = coerceToArray(p.audits);
+  if (p.audits !== undefined && !Array.isArray(p.audits)) {
+    warnings.push({ org, field: 'audits', message: 'expected a list; coerced single value to a 1-element list' });
+  }
+  const auditEntries: DotProjectAudit[] = [];
+  rawAudits.forEach((audit, i) => {
+    if (!isObject(audit)) {
+      warnings.push({ org, field: 'audits', message: `skipped non-object entry at index ${i}` });
+      return;
+    }
+    auditEntries.push({
+      org,
+      position: auditEntries.length,
+      date: toIsoString(audit.date),
+      type: toStringOrNull(audit.type),
+      url: toStringOrNull(audit.url),
+    });
+  });
 
   // ── repositories ──────────────────────────────────────────────────────────
-  const rawRepos = parsed.repositories ?? [];
-  const repoEntries: DotProjectRepository[] = rawRepos.map((url, i) => {
-    const gh = parseGithubUrl(url);
-    return {
+  // BLOCKING FIX: `repositories:` may be a scalar string (not a sequence), or
+  // may contain non-string entries. Coerce scalar→array and skip/warn on
+  // non-string entries. Relative (non-github) URLs land with null owner/name + warn.
+  const rawRepos = coerceToArray(p.repositories);
+  if (p.repositories !== undefined && !Array.isArray(p.repositories)) {
+    warnings.push({ org, field: 'repositories', message: 'expected a list; coerced single value to a 1-element list' });
+  }
+  const repoEntries: DotProjectRepository[] = [];
+  rawRepos.forEach((url, i) => {
+    if (typeof url !== 'string') {
+      warnings.push({ org, field: 'repositories', message: `skipped non-string entry at index ${i} (${typeof url})` });
+      return;
+    }
+    const trimmed = url.trim();
+    if (!trimmed) {
+      warnings.push({ org, field: 'repositories', message: `skipped empty URL at index ${i}` });
+      return;
+    }
+    const gh = parseGithubUrl(trimmed);
+    if (!gh) {
+      warnings.push({ org, field: 'repositories', message: `non-github/relative URL stored with null owner/name: ${trimmed}` });
+    }
+    repoEntries.push({
       org,
-      position: i,
-      repo_url: url,
+      position: repoEntries.length,
+      repo_url: trimmed,
       repo_owner: gh?.owner ?? null,
       repo_name: gh?.name ?? null,
-    };
+    });
   });
 
   // ── package_managers ──────────────────────────────────────────────────────
   let packageManagersJson: string | null = null;
-  if (parsed.package_managers && typeof parsed.package_managers === 'object') {
+  if (isObject(p.package_managers)) {
     try {
-      packageManagersJson = JSON.stringify(parsed.package_managers);
+      packageManagersJson = JSON.stringify(p.package_managers);
     } catch {
       packageManagersJson = null;
     }
+  } else if (p.package_managers !== undefined) {
+    warnings.push({ org, field: 'package_managers', message: 'expected a map; ignored non-object value' });
   }
+
+  // ── project_lead (validate, don't blindly coerce) ─────────────────────────
+  const leadResult = serializeProjectLead(org, p.project_lead);
+  warnings.push(...leadResult.warnings);
 
   // ── top-level record ──────────────────────────────────────────────────────
   const record: DotProjectRecord = {
     org,
     source_url: sourceUrl,
-    schema_version: parsed.schema_version ?? null,
-    slug: parsed.slug ?? null,
-    name: parsed.name ?? null,
-    description: parsed.description ?? null,
-    type: parsed.type ?? null,
-    project_lead: serializeProjectLead(parsed.project_lead),
-    repository_count: rawRepos.length,
-    website: parsed.website ?? null,
+    schema_version: toStringOrNull(p.schema_version),
+    slug: toStringOrNull(p.slug),
+    name: toStringOrNull(p.name),
+    description: toStringOrNull(p.description),
+    type: toStringOrNull(p.type),
+    project_lead: leadResult.value,
+    repository_count: repoEntries.length,
+    website: toStringOrNull(p.website),
     current_maturity: lastMaturity?.phase ?? null,
-    current_maturity_date: toIsoString(lastMaturity?.date),
-    audit_count: rawAudits.length,
-    security_policy_path: parsed.security?.policy?.path ?? null,
-    security_threat_model_path: parsed.security?.threat_model?.path ?? null,
-    security_contact_email: parsed.security?.contact?.email ?? null,
-    security_advisory_url: parsed.security?.contact?.advisory_url ?? null,
-    landscape_category: parsed.landscape?.category ?? null,
-    landscape_subcategory: parsed.landscape?.subcategory ?? null,
+    current_maturity_date: lastMaturity?.date ?? null,
+    audit_count: auditEntries.length,
+    security_policy_path: nestedString(p.security, 'policy', 'path'),
+    security_threat_model_path: nestedString(p.security, 'threat_model', 'path'),
+    security_contact_email: nestedString(p.security, 'contact', 'email'),
+    security_advisory_url: nestedString(p.security, 'contact', 'advisory_url'),
+    landscape_category: nestedString(p.landscape, 'category'),
+    landscape_subcategory: nestedString(p.landscape, 'subcategory'),
     package_managers_json: packageManagersJson,
     fetched_at: now,
   };
@@ -278,7 +418,71 @@ export function parseDotProject(
     dot_project_repositories: repoEntries,
     dot_project_maturity_log: maturityEntries,
     dot_project_audits: auditEntries,
+    dot_project_maintainers: [],
+    warnings,
   };
+}
+
+/**
+ * Parse a maintainers.yaml text blob into normalized maintainer rows.
+ * DEFENSIVE: never throws; skips malformed teams/members with warnings.
+ *
+ * @param org - GitHub org login the .project repo was fetched from (FK)
+ * @param maintainersYamlText - Raw YAML text of maintainers.yaml
+ * @returns { maintainers, warnings }
+ */
+export function parseMaintainers(
+  org: string,
+  maintainersYamlText: string
+): { maintainers: DotProjectMaintainer[]; warnings: DotProjectWarning[] } {
+  const warnings: DotProjectWarning[] = [];
+  let parsed: unknown;
+  try {
+    parsed = yaml.parse(maintainersYamlText);
+  } catch {
+    return { maintainers: [], warnings: [{ org, field: 'maintainers.yaml', message: 'YAML parse error' }] };
+  }
+
+  if (!isObject(parsed)) return { maintainers: [], warnings };
+
+  const rows: DotProjectMaintainer[] = [];
+  const entries = coerceToArray((parsed as MaintainersYaml).maintainers);
+
+  for (const entry of entries) {
+    if (!isObject(entry)) {
+      warnings.push({ org, field: 'maintainers', message: 'skipped non-object maintainer entry' });
+      continue;
+    }
+    const projectId = toStringOrNull(entry.project_id);
+    const maintainerOrg = toStringOrNull(entry.org);
+    const teams = coerceToArray(entry.teams);
+
+    for (const team of teams) {
+      if (!isObject(team)) {
+        warnings.push({ org, field: 'maintainers.teams', message: 'skipped non-object team' });
+        continue;
+      }
+      const teamName = toStringOrNull(team.name);
+      const members = coerceToArray(team.members);
+      for (const member of members) {
+        if (typeof member !== 'string') {
+          warnings.push({ org, field: 'maintainers.members', message: `skipped non-string member (${typeof member})` });
+          continue;
+        }
+        const handle = member.trim().replace(/^@/, '');
+        if (!handle) continue;
+        rows.push({
+          org,
+          project_id: projectId,
+          maintainer_org: maintainerOrg,
+          team: teamName,
+          member: handle,
+        });
+      }
+    }
+  }
+
+  return { maintainers: rows, warnings };
 }
 
 /**
@@ -293,6 +497,8 @@ export function mergeDotProjectResults(
     dot_project_repositories: [],
     dot_project_maturity_log: [],
     dot_project_audits: [],
+    dot_project_maintainers: [],
+    warnings: [],
   };
 
   for (const r of results) {
@@ -301,16 +507,23 @@ export function mergeDotProjectResults(
     merged.dot_project_repositories.push(...r.dot_project_repositories);
     merged.dot_project_maturity_log.push(...r.dot_project_maturity_log);
     merged.dot_project_audits.push(...r.dot_project_audits);
+    merged.dot_project_maintainers.push(...r.dot_project_maintainers);
+    merged.warnings.push(...r.warnings);
   }
 
   return merged;
 }
 
 export function getDotProjectStats(normalized: DotProjectNormalized): string {
-  return [
+  const lines = [
     `Normalized ${normalized.dot_project.length} .project records`,
     `  ${normalized.dot_project_repositories.length} repositories`,
     `  ${normalized.dot_project_maturity_log.length} maturity_log entries`,
     `  ${normalized.dot_project_audits.length} audits`,
-  ].join('\n');
+    `  ${normalized.dot_project_maintainers.length} maintainers`,
+  ];
+  if (normalized.warnings.length > 0) {
+    lines.push(`  ${normalized.warnings.length} schema warnings (tolerated)`);
+  }
+  return lines.join('\n');
 }


### PR DESCRIPTION
## Summary

- **`scripts/build-repo-list.ts`** — reproducible, idempotent repo-list builder that unions two sources: (a) CNCF landscape from `landscape.cncf.io/data/full.json` (`.items[]`) and (b) `.project` `repositories[]` for each CNCF project. Each entry carries `source` provenance (`landscape` / `dot-project` / `both`). Dedup on `nameWithOwner` (case-insensitive). Projects without a `.project` repo degrade gracefully (404 → skip).
- **`npm run build:repos`** added to `package.json` — runs the builder; use `--dry-run`, `--no-dot-project`, `--output`, `--verbose` flags.
- **`RUNBOOK.md`** — internal runbook with exact reproducible commands for all pipeline steps (repo list refresh → collect → graph → export → insight queries), Milestone-1 target queries, and a token/bucket requirement matrix.

## Landscape endpoint verdict

| Endpoint | Status | Content-Type | Use? |
|----------|--------|--------------|------|
| `https://landscape.cncf.io/data/items.json` | HTTP 200 (!) | `text/html` | NO — returns landscape2 SPA shell |
| `https://landscape.cncf.io/data/full.json` | HTTP 200 | `application/json` | YES — `.items[]`, 2414 entries |

The legacy `fetch-cncf-landscape.ts` uses `raw.githubusercontent.com/.../landscape.yml` (still live, unaffected). The new builder uses `full.json` and is guarded with a content-type check that throws a clear error if the endpoint drifts again.

## What ran green without a token (real output)

```
npm run graph:list          ✓ listed 7 built-in Cypher queries
npm run graph -- --database output/test-three-projects/current/database.db
                            ✓ 4286 nodes, 4286 relationships built
npm run graph:query -- --graph output/test-three-projects/current/graph.lbug --name graduated-no-signing
                            ✓ 2 rows returned
npm run graph:query -- ... --name project-tool-summary
                            ✓ 3 rows (Helm/graduated, Jaeger/graduated, KubeVela/incubating)
npm run build:repos -- --dry-run --no-dot-project
                            ✓ 251 projects, 287 repos extracted
npm run build:repos -- --dry-run
                            ✓ 251 projects, 362 repos after .project union
```

## Expanded repo-list counts (landscape ∪ .project)

- **251** CNCF projects from `full.json`
- **287** repos from landscape
- **362** unique repos after `.project` union (+75 net-new)
- **61** of 251 projects publish a `.project` repo; **9** of those contributed repos not already in the landscape

## What still needs a token vs. a bucket

| Step | Needs Token | Needs Bucket |
|------|------------|--------------|
| `npm run build:repos` | No (token raises rate limits only) | No |
| `npm start` / collect | **YES** (`GITHUB_PERSONAL_ACCESS_TOKEN`) | No |
| `npm run graph` / `graph:list` / `graph:query` | No | No |
| Parquet export | No | **YES** — set `BUCKET_URL` in RUNBOOK.md commands |

## Test plan

- [ ] `npm run build:repos -- --dry-run` reports correct counts
- [ ] `npm run build:repos -- --no-dot-project` produces landscape-only output
- [ ] `npm run build:repos` writes `input/cncf-expanded-repo-list.json`
- [ ] `npm run graph:list` lists 7 queries
- [ ] `npm run graph -- --database output/test-three-projects/current/database.db` builds graph
- [ ] `npm run graph:query -- --graph output/test-three-projects/current/graph.lbug --name graduated-no-signing` returns Helm + Jaeger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qc1xQ542tF1ExJDJPUeC9P