### PR TITLE
docs: engineering PRIMER — architecture, data model, repo-list recipe, doc audit

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -83,44 +83,88 @@ Runs the GraphQL data collector against the expanded repo list.
 ```bash
 export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx
 
-# Full landscape scan (use expanded list for maximum coverage)
+# Full landscape scan with .project metadata (recommended)
+npx ts-node src/neo.ts \
+  --input input/cncf-expanded-repo-list.json \
+  --queries GetRepoDataExtendedInfo \
+  --dot-project \
+  --analyze \
+  --parallel
+
+# Without .project metadata (faster, skips dot_project* tables)
 npx ts-node src/neo.ts \
   --input input/cncf-expanded-repo-list.json \
   --queries GetRepoDataExtendedInfo \
   --analyze \
   --parallel
 
-# Or with maturity filter (e.g., graduated only)
+# With maturity filter (e.g., graduated only) + .project
 npx ts-node src/neo.ts \
   --input input/cncf-expanded-repo-list.json \
   --queries GetRepoDataExtendedInfo \
   --maturity graduated \
+  --dot-project \
   --analyze \
   --parallel
 
-# Or use npm alias (runs against cncf-full-landscape.json)
+# Or use npm alias (runs against cncf-full-landscape.json, no --dot-project by default)
 GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx npm start
 ```
+
+### --dot-project flag
+
+When `--dot-project` is passed, the collector additionally:
+
+1. Collects all unique GitHub orgs from the scanned repos.
+2. For each org, fetches `https://github.com/<org>/.project` via the same GraphQL
+   blob-fetch mechanism used for SECURITY.md and workflow files
+   (`object(expression: "HEAD:project.yaml") { ... on Blob { text } }`).
+3. Parses the `project.yaml` YAML and normalizes it into four DuckDB tables:
+
+| Table | Description |
+|-------|-------------|
+| `dot_project` | One row per org that has a `.project` repo — top-level fields (slug, name, current maturity, security fields, etc.) |
+| `dot_project_repositories` | One row per URL in `repositories[]` — parsed into `repo_owner`/`repo_name` |
+| `dot_project_maturity_log` | One row per `maturity_log[]` entry (phase, date, issue URL) |
+| `dot_project_audits` | One row per `audits[]` entry (date, type, URL) |
+
+Orgs without a `.project` repo (the majority — ~61/251 CNCF orgs have one as of 2026)
+are silently skipped. Handle-absence is built into the GraphQL blob-fetch: a missing
+repo returns `repository: null`; a missing file returns `projectYaml: null`.
+
+**Relationship to build-repo-list.ts:**
+`build-repo-list.ts` (Step 1) also fetches `.project` repos, but via unauthenticated
+raw HTTP (`raw.githubusercontent.com`) *pre-scan* to build the repo list. The `--dot-project`
+flag fetches them *during the scan* via GraphQL with auth, normalizes all fields (not just
+`repositories[]`), and lands them in DuckDB. They are complementary:
+- Step 1 enriches the repo list with `.project` `repositories[]`
+- Step 2 `--dot-project` captures all `.project` metadata fields in DuckDB
 
 **Output structure:**
 
 ```
 output/<input-basename>/<ISO-timestamp>/
-  database.db                              ← DuckDB (base + agg tables)
-  parquet/                                 ← Parquet files per table
+  database.db                              ← DuckDB (base + agg + dot_project* tables)
+  parquet/
+    dot_project.parquet
+    dot_project_repositories.parquet
+    dot_project_maturity_log.parquet
+    dot_project_audits.parquet
+    ...other tables...
   raw-responses.GetRepoDataExtendedInfo.jsonl  ← audit log (JSONL)
   files/                                   ← SECURITY.md, security-insights.yml
-  security-insights-attestations.csv
-  security-insights-sboms.csv
 output/<input-basename>/current -> <latest-timestamp>/   ← symlink
 ```
 
 **What requires the token:**
 - All `npm start` / `npx ts-node src/neo.ts` invocations — GitHub GraphQL API requires auth.
 - `--scan-orgs` mode (org-level repo discovery) — also requires token.
+- `--dot-project` mode — also requires token (GraphQL API).
 
 **What does NOT require a token:**
 - Steps 1, 3, 4, 5 (repo list build, graph build, export, queries).
+- `.project` YAML parsing / DuckDB normalization (the `parseDotProject` function
+  is token-free and testable with local fixtures — see "Pipeline Validation" below).
 
 ---
 
@@ -384,6 +428,48 @@ npm run build:repos -- --dry-run --no-dot-project
 │ 1       │ 'Jaeger'       │ 'jaegertracing/jaeger' │
 └─────────┴────────────────┴────────────────────────┘
 2 row(s)
+```
+
+### .project Parse Validation (No Token)
+
+The `parseDotProject` normalizer can be validated without a token using local YAML fixtures.
+The example below uses the schema example at `~/gh/f/cncf/automation/utilities/dot-project/example/project.yaml`
+as a parse target, then queries the resulting DuckDB tables:
+
+```bash
+# Run the standalone .project parse test (no network, no token)
+npx ts-node scripts/test-dot-project-parse.ts
+
+# Or validate the normalizer unit test
+npx ts-node -e "
+const { parseDotProject } = require('./src/normalizers/DotProjectNormalizer');
+const fs = require('fs');
+const yaml = fs.readFileSync('./input/test-dot-project-argoproj.yaml', 'utf-8');
+const result = parseDotProject('argoproj', yaml, 'https://github.com/argoproj/.project/blob/HEAD/project.yaml');
+console.log(JSON.stringify(result, null, 2));
+"
+```
+
+For an end-to-end test against a real `.project` repo without a GraphQL token,
+use the unauthenticated raw fetch (same as `build-repo-list.ts` Step 1):
+
+```bash
+# Fetch argoproj/.project/project.yaml via raw.githubusercontent.com (no auth)
+curl -s https://raw.githubusercontent.com/argoproj/.project/main/project.yaml | \
+  npx ts-node -e "
+const { parseDotProject } = require('./src/normalizers/DotProjectNormalizer');
+const fs = require('fs');
+process.stdin.resume();
+let data = '';
+process.stdin.on('data', d => data += d);
+process.stdin.on('end', () => {
+  const result = parseDotProject('argoproj', data, 'test');
+  console.log(JSON.stringify(result?.dot_project[0], null, 2));
+  console.log('repositories:', result?.dot_project_repositories.length);
+  console.log('maturity entries:', result?.dot_project_maturity_log.length);
+  console.log('audits:', result?.dot_project_audits.length);
+});
+"
 ```
 
 ---

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,426 @@
+# Supply-Chain Security Collector — Internal Runbook
+
+**Purpose:** Reproducible commands for the full data pipeline: repo-list refresh → collect → graph → export → query.
+This is an internal engineering reference, not a CNCF report.
+
+---
+
+## Pipeline Overview
+
+```
+[1] build:repos      → input/cncf-expanded-repo-list.json   (no token needed)
+[2] npm start        → output/<name>/<ts>/database.db        (GitHub token required)
+[3] npm run graph    → output/<name>/<ts>/graph.lbug          (no token needed)
+[4] export parquet   → bucket/<name>/<ts>/parquet/            (bucket URL needed)
+[5] insight queries  → npm run graph:query / DuckDB SQL       (no token needed)
+```
+
+---
+
+## Step 1 — Refresh the Repo List
+
+Builds `input/cncf-expanded-repo-list.json` by UNION-ing:
+- **(a)** CNCF landscape repos from `https://landscape.cncf.io/data/full.json` (`.items[]`)
+- **(b)** `.project` `repositories[]` for each CNCF project (fetched from
+  `https://raw.githubusercontent.com/<org>/.project/main/project.yaml`)
+
+Each entry carries a `source` field: `"landscape"`, `"dot-project"`, or `"both"`.
+Deduplication is on `owner/name` (case-insensitive).
+
+### Run
+
+```bash
+# Full build: landscape + .project (recommended)
+npm run build:repos
+
+# Landscape only (no network calls to .project repos)
+npm run build:repos -- --no-dot-project
+
+# Custom output path
+npm run build:repos -- --output input/my-custom-list.json
+
+# Dry-run: print counts, don't write files
+npm run build:repos -- --dry-run
+
+# Verbose: log each .project repo discovered
+npm run build:repos -- --verbose
+```
+
+### Optional: GitHub token to avoid rate-limiting
+
+Without a token, all fetches use unauthenticated `raw.githubusercontent.com` GETs
+(fine for public repos; degraded if GitHub starts rate-limiting unauthenticated GETs).
+
+```bash
+GITHUB_TOKEN=ghp_xxx npm run build:repos
+# or
+GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx npm run build:repos
+```
+
+### What this replaces
+
+Previously, `npm run fetch:landscape` fetched `landscape.yml` from GitHub raw and produced
+`input/cncf-full-landscape.json` (landscape repos only). The new `build:repos` script
+supersedes it and adds `.project` enrichment.
+
+> **Landscape endpoint note:**
+> `https://landscape.cncf.io/data/items.json` returns HTML (landscape2 SPA shell) — DEAD.
+> `https://landscape.cncf.io/data/full.json` returns `application/json` with `.items[]` — USE THIS.
+> `build-repo-list.ts` uses `full.json`. The legacy `fetch-cncf-landscape.ts` uses
+> `raw.githubusercontent.com/.../landscape.yml` (also fine — YAML source is still live).
+
+### Idempotency
+
+Running `build:repos` multiple times produces the same output given the same upstream state.
+The script is stateless — no local cache is written.
+
+---
+
+## Step 2 — Full Scan (GitHub token required)
+
+Runs the GraphQL data collector against the expanded repo list.
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx
+
+# Full landscape scan (use expanded list for maximum coverage)
+npx ts-node src/neo.ts \
+  --input input/cncf-expanded-repo-list.json \
+  --queries GetRepoDataExtendedInfo \
+  --analyze \
+  --parallel
+
+# Or with maturity filter (e.g., graduated only)
+npx ts-node src/neo.ts \
+  --input input/cncf-expanded-repo-list.json \
+  --queries GetRepoDataExtendedInfo \
+  --maturity graduated \
+  --analyze \
+  --parallel
+
+# Or use npm alias (runs against cncf-full-landscape.json)
+GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx npm start
+```
+
+**Output structure:**
+
+```
+output/<input-basename>/<ISO-timestamp>/
+  database.db                              ← DuckDB (base + agg tables)
+  parquet/                                 ← Parquet files per table
+  raw-responses.GetRepoDataExtendedInfo.jsonl  ← audit log (JSONL)
+  files/                                   ← SECURITY.md, security-insights.yml
+  security-insights-attestations.csv
+  security-insights-sboms.csv
+output/<input-basename>/current -> <latest-timestamp>/   ← symlink
+```
+
+**What requires the token:**
+- All `npm start` / `npx ts-node src/neo.ts` invocations — GitHub GraphQL API requires auth.
+- `--scan-orgs` mode (org-level repo discovery) — also requires token.
+
+**What does NOT require a token:**
+- Steps 1, 3, 4, 5 (repo list build, graph build, export, queries).
+
+---
+
+## Step 3 — Build the Graph (LadybugDB)
+
+Reads the DuckDB output from Step 2 and builds a LadybugDB property graph
+for Cypher-based supply chain security queries.
+
+```bash
+# Build graph from the latest collect run (using the 'current' symlink)
+npm run graph -- --database output/cncf-expanded-repo-list/current/database.db
+
+# Or specify explicit timestamp directory
+npm run graph -- --database output/cncf-expanded-repo-list/2026-07-17T12-00-00/database.db
+
+# Optional: custom output graph path
+npm run graph -- \
+  --database output/cncf-expanded-repo-list/current/database.db \
+  --output output/cncf-expanded-repo-list/current/graph.lbug
+```
+
+**Output:** `graph.lbug` directory alongside the `database.db`.
+
+**List available Cypher queries:**
+
+```bash
+npm run graph:list
+```
+
+---
+
+## Step 4 — Export DuckDB + Parquet to Bucket
+
+> Replace `BUCKET_URL` with your actual bucket path (e.g. `s3://my-bucket/supply-chain/`
+> or `gs://my-bucket/supply-chain/`).
+
+### Export Parquet files
+
+```bash
+BUCKET_URL="s3://my-bucket/supply-chain"
+RUN_DIR="output/cncf-expanded-repo-list/current"
+
+# Copy the full run directory (DuckDB + Parquet + audit log)
+aws s3 cp --recursive "${RUN_DIR}/parquet/" "${BUCKET_URL}/parquet/"
+aws s3 cp "${RUN_DIR}/database.db" "${BUCKET_URL}/database.db"
+aws s3 cp "${RUN_DIR}/raw-responses.GetRepoDataExtendedInfo.jsonl" \
+          "${BUCKET_URL}/raw-responses.GetRepoDataExtendedInfo.jsonl"
+```
+
+### Export with DuckDB COPY (direct from database)
+
+```bash
+# Example: export a specific table to Parquet in the bucket
+duckdb output/cncf-expanded-repo-list/current/database.db \
+  "COPY base_repositories TO '${BUCKET_URL}/base_repositories.parquet' (FORMAT PARQUET)"
+```
+
+### Read Parquet from bucket in DuckDB (for remote analysis)
+
+```bash
+duckdb :memory: \
+  "SELECT * FROM read_parquet('${BUCKET_URL}/parquet/base_repositories.parquet') LIMIT 10"
+```
+
+---
+
+## Step 5 — Run Insight Queries
+
+### Cypher queries (graph)
+
+Run against the LadybugDB graph built in Step 3.
+
+```bash
+GRAPH_PATH="output/cncf-expanded-repo-list/current/graph.lbug"
+
+# List all built-in queries
+npm run graph:list
+
+# Run a built-in query
+npm run graph:query -- --graph "${GRAPH_PATH}" --name graduated-no-signing
+npm run graph:query -- --graph "${GRAPH_PATH}" --name project-tool-summary
+npm run graph:query -- --graph "${GRAPH_PATH}" --name tool-cooccurrence
+npm run graph:query -- --graph "${GRAPH_PATH}" --name maturity-tool-adoption
+npm run graph:query -- --graph "${GRAPH_PATH}" --name full-pipeline
+npm run graph:query -- --graph "${GRAPH_PATH}" --name unmonitored-graduated
+
+# Run an ad-hoc Cypher query
+npm run graph:query -- \
+  --graph "${GRAPH_PATH}" \
+  --cypher "MATCH (p:CNCFProject)<-[:BELONGS_TO]-(r:Repository) RETURN p.display_name, count(r) AS repos ORDER BY repos DESC LIMIT 20"
+
+# Run a query from a .cypher file
+npm run graph:query -- --graph "${GRAPH_PATH}" --file cypher/maturity-tool-adoption.cypher
+```
+
+### SQL queries (DuckDB)
+
+```bash
+DB_PATH="output/cncf-expanded-repo-list/current/database.db"
+
+# List tables
+duckdb "${DB_PATH}" ".tables"
+
+# Basic provenance check
+duckdb "${DB_PATH}" \
+  "SELECT maturity, count(*) AS projects, sum(repo_count) AS repos
+   FROM agg_project_summary GROUP BY maturity ORDER BY maturity"
+
+# Workflow tool usage by project
+duckdb "${DB_PATH}" \
+  "SELECT project_name, tool_name, category
+   FROM agg_workflow_tools ORDER BY project_name, category"
+```
+
+---
+
+## Milestone-1 Target Queries
+
+These are the Milestone-1 analytical questions. Implement as Cypher or SQL against
+the graph/DuckDB built above.
+
+### Q1 — License "rug pull" impact
+
+> *Which CNCF projects changed their license? How many downstream dependents
+> (by release asset count or workflow SBOM references) are potentially impacted?*
+
+**Approach:** The current schema captures `license` per project from the landscape.
+A rug-pull signal requires a historical diff (not yet implemented). For now, identify
+projects whose landscape-declared license differs from what the collector read from
+their GitHub repo's `license_info.spdx_id`:
+
+```sql
+-- DuckDB: projects where landscape-declared license differs from GitHub-detected license
+SELECT
+    r.project_name,
+    r.maturity,
+    r.landscape_license,
+    r.github_license
+FROM base_repositories r
+WHERE r.landscape_license IS NOT NULL
+  AND r.github_license IS NOT NULL
+  AND r.landscape_license != r.github_license
+ORDER BY r.maturity, r.project_name;
+```
+
+```cypher
+// Cypher: graduated projects with a mismatched or missing license
+MATCH (p:CNCFProject {maturity: 'graduated'})<-[:BELONGS_TO]-(r:Repository)
+WHERE r.landscape_license IS NOT NULL
+  AND (r.github_license IS NULL OR r.landscape_license <> r.github_license)
+RETURN p.display_name, r.nameWithOwner, r.landscape_license, r.github_license
+ORDER BY p.display_name
+```
+
+### Q2 — CVE impact across the CNCF ecosystem
+
+> *Which CVEs (from security-insights.yml / SBOM attestations) affect the most
+> CNCF projects? What is the blast radius?*
+
+**Approach:** `security-insights.yml` files (collected in `files/`) and SBOM assets
+from releases. The collector writes `security-insights-sboms.csv` and
+`security-insights-attestations.csv`. Query across projects:
+
+```sql
+-- DuckDB: release assets that look like SBOM or attestation files
+SELECT
+    r.project_name,
+    r.nameWithOwner,
+    ra.name AS asset_name,
+    ra.download_count
+FROM base_release_assets ra
+JOIN base_repositories r ON r.id = ra.repository_id
+WHERE lower(ra.name) LIKE '%sbom%'
+   OR lower(ra.name) LIKE '%.intoto.jsonl'
+   OR lower(ra.name) LIKE '%.att'
+ORDER BY r.project_name, ra.name;
+```
+
+```cypher
+// Cypher (graph Q15): landscape question — projects with SBOM assets but no signing tool
+MATCH (p:CNCFProject)<-[:BELONGS_TO]-(r:Repository)-[:HAS_RELEASE]->(rel:Release)-[:HAS_ASSET]->(a:ReleaseAsset)
+WHERE a.name CONTAINS 'sbom'
+  AND NOT EXISTS {
+      MATCH (r)-[:HAS_WORKFLOW]->(:Workflow)-[:USES_TOOL]->(t:Tool)
+      WHERE t.tool_name IN ['cosign', 'sigstore', 'notation']
+  }
+RETURN p.display_name, p.maturity, r.nameWithOwner,
+       count(DISTINCT rel) AS releases_with_sbom
+ORDER BY p.maturity, p.display_name
+```
+
+### Q3 — Landscape graph question #15
+
+> *Which graduated projects publish SBOM assets in releases but have no signing
+> tool detected in any CI workflow?*
+
+```cypher
+MATCH (p:CNCFProject {maturity: 'graduated'})<-[:BELONGS_TO]-(r:Repository)
+      -[:HAS_RELEASE]->(rel:Release)-[:HAS_ASSET]->(a:ReleaseAsset)
+WHERE (a.name CONTAINS 'sbom' OR a.name CONTAINS '.spdx' OR a.name CONTAINS '.cyclonedx')
+  AND NOT EXISTS {
+      MATCH (r)-[:HAS_WORKFLOW]->(:Workflow)-[:USES_TOOL]->(t:Tool)
+      <-[:IN_CATEGORY]-(:ToolCategory {category_name: 'signer'})
+  }
+RETURN p.display_name, r.nameWithOwner,
+       count(DISTINCT a) AS sbom_assets,
+       count(DISTINCT rel) AS releases
+ORDER BY sbom_assets DESC
+```
+
+---
+
+## What Needs a Token vs. What Needs a Bucket
+
+| Step | Needs GitHub Token | Needs Bucket |
+|------|-------------------|--------------|
+| `npm run build:repos` | No (but helps with rate limits) | No |
+| `npm run fetch:landscape` | No | No |
+| `npm start` / `npm run test:three` | **YES** | No |
+| `npm run graph` | No | No |
+| `npm run graph:list` | No | No |
+| `npm run graph:query` | No | No |
+| Parquet export to bucket | No | **YES** — set `BUCKET_URL` |
+| Remote Parquet reads via httpfs | No | **YES** |
+| `npm run analyze` / `npm run report` | No | No |
+
+---
+
+## Pipeline Validation (Without Token)
+
+The following runs green without a GitHub token, using committed test fixtures
+in `output/test-three-projects/`:
+
+```bash
+# 1. List available Cypher queries
+npm run graph:list
+
+# 2. Build graph from committed test fixture
+npm run graph -- --database output/test-three-projects/current/database.db
+
+# 3. Run a Cypher query on the test graph
+npm run graph:query -- \
+  --graph output/test-three-projects/current/graph.lbug \
+  --name graduated-no-signing
+
+# 4. Run project-tool-summary
+npm run graph:query -- \
+  --graph output/test-three-projects/current/graph.lbug \
+  --name project-tool-summary
+
+# 5. Dry-run the repo list builder (no writes, no token)
+npm run build:repos -- --dry-run --no-dot-project
+```
+
+**Expected output for `graduated-no-signing` on test fixture:**
+```
+┌─────────┬────────────────┬────────────────────────┐
+│ (index) │ p.display_name │ r.nameWithOwner        │
+├─────────┼────────────────┼────────────────────────┤
+│ 0       │ 'Helm'         │ 'helm/helm'            │
+│ 1       │ 'Jaeger'       │ 'jaegertracing/jaeger' │
+└─────────┴────────────────┴────────────────────────┘
+2 row(s)
+```
+
+---
+
+## Troubleshooting
+
+### `items.json` returns HTML instead of JSON
+
+**Symptom:** `fetch-cncf-landscape.ts` or a custom script hits
+`https://landscape.cncf.io/data/items.json` and gets `content-type: text/html`.
+
+**Cause:** The landscape2 migration moved the data to `full.json`. The `items.json`
+URL now returns the SPA shell HTML.
+
+**Fix:** Change the URL to `https://landscape.cncf.io/data/full.json` and access
+`.items[]` instead of the top-level array. The `build-repo-list.ts` script already
+uses `full.json`.
+
+### `.project` repos return 404
+
+Most CNCF projects have not yet published a `.project` repo. The builder degrades
+gracefully — 404s are silently skipped, and the landscape data is used as-is.
+As more projects adopt `.project`, the builder will automatically pick them up.
+
+### DuckDB extension install failures
+
+Extensions (`json`, `parquet`, `fts`, `httpfs`) are auto-installed on first run.
+If you're in an air-gapped environment:
+
+```bash
+# Pre-install extensions manually
+duckdb :memory: "INSTALL json; INSTALL parquet; INSTALL fts; INSTALL httpfs"
+```
+
+### Graph build skips tables
+
+If `graph.lbug` is missing expected tables (e.g., `Tool`, `ToolCategory`), the
+collect run may not have detected any workflow tool usage. This is expected for
+projects with no GitHub Actions workflows, or workflows that use unrecognized tools.
+Check `agg_workflow_tools` in the DuckDB database.

--- a/docs/PRIMER.md
+++ b/docs/PRIMER.md
@@ -1,0 +1,433 @@
+# Supply Chain Security Collector — Engineering Primer
+
+**Purpose:** Durable internal reference for contributors and operators.  
+**Scope:** Architecture, data model, pipeline stages, utility scripts, repo-list maintenance, and documentation audit.  
+**Not a CNCF report** — the CNCF-facing findings live in `docs/presentations/`.
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#1-architecture-overview)
+2. [End-to-End Pipeline](#2-end-to-end-pipeline)
+3. [Full Data Model](#3-full-data-model)
+4. [Utility Scripts and Repo-List Maintenance](#4-utility-scripts-and-repo-list-maintenance)
+5. [Graph Layer (LadybugDB)](#5-graph-layer-ladybugdb)
+6. [Documentation Audit](#6-documentation-audit)
+
+---
+
+## 1. Architecture Overview
+
+```mermaid
+flowchart TD
+    subgraph inputs["Input Sources"]
+        LS["CNCF Landscape\nlandscape.cncf.io/data/full.json"]
+        DP[".project repos\ngithub.com/<org>/.project/project.yaml"]
+        LOCAL["Committed test fixtures\ninput/*.json"]
+    end
+
+    subgraph build["Step 1 — Repo List Build (no token)"]
+        BRL["build-repo-list.ts\nnpm run build:repos"]
+        FL["fetch-cncf-landscape.ts\nnpm run fetch:landscape (legacy)"]
+    end
+
+    subgraph collect["Step 2 — Collection (GitHub token required)"]
+        NEO["neo.ts\nnpm start / npm run collect"]
+        API["api.ts\nGitHub GraphQL client"]
+        NORM["normalizers/\nGetRepoDataExtendedInfoNormalizer\nDotProjectNormalizer\nGetOrgReposNormalizer"]
+        AW["ArtifactWriter.ts\nDuckDB writer"]
+    end
+
+    subgraph store["DuckDB Artifacts"]
+        RAW["raw_* tables\nFull GraphQL JSON"]
+        BASE["base_* tables\nNormalized relational"]
+        DOTPROJ["dot_project* tables\n.project metadata"]
+        PARQUET["parquet/ directory\nAll tables as Parquet"]
+        FILES["files/\nExtracted file content"]
+    end
+
+    subgraph analyze["Step 3 — Analysis (no token)"]
+        SA["SecurityAnalyzer.ts\nnpm run analyze"]
+        SQLM["sql/models/\n00-06 SQL models"]
+        AGG["agg_* tables\nSecurity signals"]
+    end
+
+    subgraph graph["Step 4 — Property Graph (no token)"]
+        GB["GraphBuilder.ts\nnpm run graph"]
+        LBUG["graph.lbug\nLadybugDB database"]
+        CYPH["graph:query\nCypher queries"]
+    end
+
+    subgraph report["Step 5 — Reporting (no token)"]
+        RPT["ReportGenerator.ts\nnpm run report"]
+        SITE["site/\nDuckDB-WASM browser explorer"]
+    end
+
+    LS --> BRL
+    DP --> BRL
+    BRL --> |"input/cncf-expanded-repo-list.json"| NEO
+    LOCAL --> NEO
+    FL --> |"input/cncf-full-landscape.json (legacy)"| NEO
+
+    NEO --> API
+    API --> NORM
+    NORM --> AW
+    AW --> RAW
+    AW --> BASE
+    AW --> DOTPROJ
+    AW --> PARQUET
+    AW --> FILES
+
+    BASE --> SA
+    SA --> SQLM
+    SQLM --> AGG
+
+    BASE --> GB
+    AGG --> GB
+    GB --> LBUG
+    LBUG --> CYPH
+
+    AGG --> RPT
+    PARQUET --> SITE
+```
+
+### Key design decisions
+
+- **GitHub GraphQL only** — all data is collected through one API endpoint. Limitations: no OCI registry, no package manager provenance, no non-GitHub CI. Every number is a lower bound.
+- **DuckDB as the hub** — raw JSON → base tables → agg tables all live in a single `database.db`. Parquet exports allow any downstream tool to consume the data.
+- **No state between runs** — each `npm start` produces a fresh timestamped directory under `output/`. A `current` symlink tracks the latest.
+- **Two input formats** — simple `RepositoryTarget[]` (owner/name only) or rich `ProjectMetadata[]` (generated from landscape, includes CNCF maturity, dates, audit counts). The rich format is needed for CNCF analysis tables (`base_cncf_projects`, `agg_cncf_project_summary`).
+
+---
+
+## 2. End-to-End Pipeline
+
+### Stage 1 — Repo list build (`scripts/`)
+
+| Script | npm alias | Source of truth | Output |
+|--------|-----------|-----------------|--------|
+| `build-repo-list.ts` | `npm run build:repos` | `landscape.cncf.io/data/full.json` + per-org `.project/project.yaml` | `input/cncf-expanded-repo-list.json` |
+| `fetch-cncf-landscape.ts` | `npm run fetch:landscape` | `raw.githubusercontent.com/cncf/landscape/master/landscape.yml` | `input/cncf-full-landscape.json` (legacy) |
+
+**`build-repo-list.ts` is the current recommended path.** It UNIONs two sources:
+1. `full.json` — the CNCF landscape REST endpoint (machine-readable JSON, 239+ projects).
+2. Per-org `.project` repos — raw HTTPS fetches to `raw.githubusercontent.com/<org>/.project/main/project.yaml`, adding repos not captured by the landscape.
+
+Each entry carries a `source` field: `"landscape"` | `"dot-project"` | `"both"`. Deduplication is on `owner/name` (case-insensitive).
+
+**`fetch-cncf-landscape.ts` (legacy)** fetches `landscape.yml` from the CNCF GitHub repo directly and produces `cncf-full-landscape.json`. It remains functional but does not add `.project` enrichment. The `npm start` script still points to `cncf-full-landscape.json` for backward compatibility.
+
+### Stage 2 — Collection (`src/neo.ts`)
+
+Entry point: `ts-node src/neo.ts` (aliased as `npm start` / `npm run landscape` / `npm run collect`).
+
+**Key CLI flags:**
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `--input <file>` | required | Path to input JSON |
+| `--queries <name>` | `GetRepoDataExtendedInfo` | GraphQL query to run |
+| `--parallel` | false | Batch size 5, 1 s delay between batches |
+| `--analyze` | false | Run SQL analysis after collection |
+| `--maturity <levels>` | (all) | Filter by `graduated`, `incubating`, `sandbox`, `archived` |
+| `--repo-scope <scope>` | `primary` | `primary` = only `primary: true` repos; `all` = every repo |
+| `--scan-orgs` | false | Discover all repos across orgs in input (populates `base_org_repos`) |
+| `--dot-project` | false | Fetch `<org>/.project/project.yaml` via GraphQL for all orgs scanned, write `dot_project*` tables |
+
+**Collection flow per repo:**
+1. `createApiClient()` — GraphQL client with Bearer token.
+2. `fetchRepositoryExtendedInfo()` — fires `GetRepoDataExtendedInfo` query, handles rate limits.
+3. Raw response appended to `raw-responses.GetRepoDataExtendedInfo.jsonl`.
+4. `writeArtifacts()` — normalizes and writes to DuckDB.
+
+**Files extracted per repo** (written to `files/` when `--persist-files` is true, which is the default):
+- `.github/workflows/*.yml` — all workflow files (content stored in `base_workflows`)
+- `SECURITY.md` (or `.github/SECURITY.md`) — content stored in `base_security_md`
+- `SECURITY-INSIGHTS.yml` / `security-insights.yml` (root or `.github/`) — parsed as YAML, stored as JSON in `base_si_documents`
+
+**GraphQL files fetched per repo** (via `object(expression: "HEAD:<path>") { ... on Blob { text } }`):
+- `HEAD:SECURITY.md`
+- `HEAD:.github/dependabot.yml`
+- `HEAD:.github/workflows` (Tree, then entries as Blobs)
+- `HEAD:SECURITY-INSIGHTS.yml`, `HEAD:security-insights.yml`, `HEAD:.github/SECURITY-INSIGHTS.yml`, `HEAD:.github/security-insights.yml` (all four variants checked)
+
+### Stage 3 — Analysis (`src/SecurityAnalyzer.ts`)
+
+Triggered by `--analyze` flag or `npm run analyze`. Runs SQL models in order:
+
+| Model | Creates | Description |
+|-------|---------|-------------|
+| `00_initialize_indexes.sql` | FTS index on `base_workflows` | BM25 full-text search index for workflow content |
+| `01_artifact_analysis.sql` | `agg_artifact_patterns` | Classifies release assets (SBOM, signature, attestation, VEX, SLSA, etc.) |
+| `01a_security_insights_flattener.sql` | `base_si_sboms`, `agg_si_attestations` | Flattens Security Insights YAML JSON into rows |
+| `02_workflow_tool_detection.sql` | `agg_workflow_tools` | Detects security tools in workflows via FTS BM25 |
+| `03_repository_security_summary.sql` | `agg_repo_summary` | Repo-level rollup of all security signals |
+| `04_summary_views.sql` | `agg_executive_summary`, `agg_tool_summary`, `agg_repo_summary_sorted`, `agg_sbom_summary`, `agg_advanced_artifacts`, `agg_tool_category_summary`, `agg_repo_detail` | Summary and view tables |
+| `05_cncf_project_analysis.sql` | `agg_cncf_project_summary` | CNCF project-level rollup (requires rich input format) |
+| `06_org_ci_visibility.sql` | org-level CI visibility | Requires `--scan-orgs` data |
+
+After analysis, `agg_*` tables are exported to `parquet/`, and two CSV files are exported:
+- `security-insights-sboms.csv`
+- `security-insights-attestations.csv`
+
+### Stage 4 — Graph (`src/graph/`)
+
+`npm run graph -- --database <path>` builds a LadybugDB property graph from the DuckDB.
+
+**Node tables:** `Repository`, `Release`, `ReleaseAsset`, `Workflow`, `CNCFProject`, `Tool`, `ToolCategory`
+
+**Relationship tables:** `HAS_RELEASE`, `HAS_ASSET`, `HAS_WORKFLOW`, `BELONGS_TO`, `USES_TOOL`, `IN_CATEGORY`
+
+**Built-in Cypher queries** (`npm run graph:list`):
+- `graduated-no-signing` — graduated projects with no signing tools in any workflow
+- `tool-cooccurrence` — tool co-occurrence across workflow files
+- `full-pipeline` — repos with SBOM assets + cosign/sigstore in workflows
+- `maturity-tool-adoption` — tool category adoption by CNCF maturity level
+- `project-tool-summary` — all tools used by each CNCF project
+- `repos-by-tool` — repositories using a specific tool
+- `unmonitored-graduated` — graduated projects with no detected CI security tools at all
+
+### Stage 5 — Reporting
+
+- `npm run report -- --database <path>` — Markdown report via `ReportGenerator.ts`
+- `site/` — DuckDB-WASM browser explorer ([live](https://halcyondude.github.io/supply-chain-security-collector/)), pre-loaded with committed Parquet data
+
+---
+
+## 3. Full Data Model
+
+### Layer overview
+
+| Prefix | Source | Description |
+|--------|--------|-------------|
+| `raw_*` | `ArtifactWriter.ts` | Full GraphQL JSON via `read_json()`, maximum nesting depth preserved |
+| `base_*` | TypeScript normalizers + `ArtifactWriter.ts` | Flat relational entities with FKs |
+| `dot_project*` | `DotProjectNormalizer.ts` + `ArtifactWriter.ts` | `.project` metadata (no `base_` prefix) |
+| `agg_*` | `sql/models/` SQL | Analysis results and rollups |
+
+### `raw_*` tables
+
+| Table | Populated by | Description |
+|-------|-------------|-------------|
+| `raw_GetRepoDataExtendedInfo` | `ArtifactWriter.ts` | One column per GraphQL field (auto-detected), nested structs preserved as JSON |
+
+### `base_*` tables (collection layer)
+
+| Table | Normalizer / Source | Key columns |
+|-------|--------------------|-----------  |
+| `base_repositories` | `GetRepoDataExtendedInfoNormalizer` | `id` (PK), `nameWithOwner`, `url`, `description`, `hasVulnerabilityAlertsEnabled`, `license_key/name/spdxId`, `defaultBranch_name` |
+| `base_branch_protection_rules` | `GetRepoDataExtendedInfoNormalizer` | `id` (generated), `repository_id` (FK), `allowsDeletions`, `allowsForcePushes`, `requiresStatusChecks`, `requiresCodeOwnerReviews`, `pattern`, `isDefaultBranch` |
+| `base_releases` | `GetRepoDataExtendedInfoNormalizer` | `id` (PK), `repository_id` (FK), `name`, `tagName`, `url`, `createdAt` |
+| `base_release_assets` | `GetRepoDataExtendedInfoNormalizer` | `id` (PK), `release_id` (FK), `name`, `downloadUrl` |
+| `base_workflows` | `GetRepoDataExtendedInfoNormalizer` | `id` (generated: `{repo_id}_{filename}`), `repository_id` (FK), `filename`, `content` (full YAML text) |
+| `base_security_md` | `GetRepoDataExtendedInfoNormalizer` | `id` (generated), `repository_id` (FK), `path`, `content` |
+| `base_si_documents` | `ArtifactWriter.ts` (inline) | `repo_id` + `source_url` (PK composite), `schema_version`, `document` (JSON blob), `fetched_at` |
+| `base_si_sboms` | `01a_security_insights_flattener.sql` | Rows extracted from `document` JSON; one row per SBOM entry declared in security-insights |
+| `base_cncf_projects` | `ArtifactWriter.createCNCFTables()` | One row per CNCF project; rich-format input only. 35+ columns including maturity dates, audit metadata, URLs |
+| `base_cncf_project_repos` | `ArtifactWriter.createCNCFTables()` | Junction: `project_name` + `owner` + `name` + `primary` + `branch` |
+| `base_org_repos` | `ArtifactWriter.writeOrgRepoArtifacts()` | One row per repo discovered via `--scan-orgs`; `cncf_project_name` FK |
+
+### `dot_project*` tables (`.project` metadata)
+
+Added by `--dot-project` flag; written by `ArtifactWriter.writeDotProjectArtifacts()` using `DotProjectNormalizer.parseDotProject()`.
+
+| Table | PK / FK | Key columns |
+|-------|---------|-------------|
+| `dot_project` | `org` (PK) | `source_url`, `schema_version`, `slug`, `name`, `type`, `project_lead`, `repository_count`, `website`, `current_maturity`, `current_maturity_date`, `audit_count`, `security_policy_path`, `security_threat_model_path`, `security_contact_email`, `security_advisory_url`, `landscape_category/subcategory`, `package_managers_json`, `fetched_at` |
+| `dot_project_repositories` | `org` + `position` | `repo_url`, `repo_owner`, `repo_name` — one row per URL in `repositories[]` |
+| `dot_project_maturity_log` | `org` + `position` | `phase`, `date`, `issue` — one row per `maturity_log[]` entry |
+| `dot_project_audits` | `org` + `position` | `date`, `type`, `url` — one row per `audits[]` entry |
+
+**Source schema:** `github.com/<org>/.project` → `project.yaml`. Reference schema at `~/gh/f/cncf/automation/utilities/dot-project/SCHEMA.md`.
+
+### `agg_*` tables (analysis layer)
+
+| Table | SQL model | Description |
+|-------|-----------|-------------|
+| `agg_artifact_patterns` | `01_artifact_analysis.sql` | One row per release asset classification: `is_sbom`, `sbom_format`, `is_signature`, `is_attestation`, `is_vex`, `is_slsa_provenance`, `is_in_toto_*`, `is_sigstore_bundle`, `is_container_attestation`, `is_license_file` |
+| `agg_workflow_tools` | `02_workflow_tool_detection.sql` | One row per tool detection: `workflow_id`, `repository_id`, `nameWithOwner`, `workflow_name`, `tool_category`, `tool_name`. Categories: `sbom-generator`, `signer`, `goreleaser`, `vulnerability-scanner`, `dependency-scanner`, `code-scanner`, `container-scanner` |
+| `agg_repo_summary` | `03_repository_security_summary.sql` | One row per repo: aggregated booleans for every signal (has_sbom_artifact, uses_cosign, uses_codeql, etc.), counts, dates |
+| `agg_executive_summary` | `04_summary_views.sql` | Single-row overall statistics |
+| `agg_tool_summary` | `04_summary_views.sql` | One row per detected tool with repo count and adoption % |
+| `agg_repo_summary_sorted` | `04_summary_views.sql` | Pre-sorted repo list for reports |
+| `agg_sbom_summary` | `04_summary_views.sql` | SBOM format counts (SPDX, CycloneDX, unknown) |
+| `agg_advanced_artifacts` | `04_summary_views.sql` | Counts for VEX, SLSA, in-toto, sigstore bundles, SWID tags |
+| `agg_tool_category_summary` | `04_summary_views.sql` | Tools grouped by category |
+| `agg_repo_detail` | `04_summary_views.sql` | Pre-sorted detailed repo metrics |
+| `agg_si_attestations` | `01a_security_insights_flattener.sql` | Flattened attestations from security-insights.yml |
+| `agg_cncf_project_summary` | `05_cncf_project_analysis.sql` | 60+ column CNCF project rollup; rich-format only |
+
+### Entity-relationship summary
+
+```
+base_cncf_projects ─── base_cncf_project_repos ──┐
+                                                   ↓
+base_repositories ─── base_releases ─── base_release_assets
+      │
+      ├─── base_workflows         (→ agg_workflow_tools via FTS)
+      ├─── base_branch_protection_rules
+      ├─── base_security_md
+      └─── base_si_documents ──── base_si_sboms
+                              └── agg_si_attestations
+
+dot_project ─── dot_project_repositories
+           ├─── dot_project_maturity_log
+           └─── dot_project_audits
+
+base_org_repos  (standalone; org-level discovery via --scan-orgs)
+```
+
+---
+
+## 4. Utility Scripts and Repo-List Maintenance
+
+### All scripts inventory
+
+| Script | Location | npm alias | Purpose |
+|--------|----------|-----------|---------|
+| `build-repo-list.ts` | `scripts/` | `npm run build:repos` | **Primary repo-list builder.** Fetches `full.json` + `.project` repos, deduplicates, writes `input/cncf-expanded-repo-list.json` |
+| `fetch-cncf-landscape.ts` | `scripts/` | `npm run fetch:landscape` | **Legacy.** Fetches `landscape.yml` from GitHub raw, produces `input/cncf-full-landscape.json` (no `.project` enrichment) |
+| `ensure-env.sh` | `scripts/` | (manual) | Checks required env vars before a run |
+| `run-cncf-all.sh` | `scripts/` | (manual) | Shell convenience wrapper for a full landscape collect run |
+| `run-target.sh` | `scripts/` | (manual) | Run collector against a specific target |
+| `test-dot-project-duckdb.ts` | `scripts/` | (manual) | End-to-end validation of `.project` → DuckDB write |
+| `test-dot-project-parse.ts` | `scripts/` | (manual) | Unit test for `DotProjectNormalizer` without network or token |
+| `view-parquet.sh` | `scripts/` | (manual) | Shell helper to view Parquet files via DuckDB CLI |
+| `wget-clomonitor-data.sh` | `scripts/` | (manual) | Download CLOMonitor JSON data (input for analysis; not wired into main pipeline) |
+| `fetch-cncf-landscape-old.ts` | `scripts/` | (dead) | Superseded by `fetch-cncf-landscape.ts` — safe to delete |
+
+### Repo-list refresh: canonical recipe
+
+**When to refresh:** CNCF adds/removes projects and changes maturity levels continuously. The committed `input/cncf-full-landscape.json` was last updated **2026-02-02** (commit `1011f44`). As of 2026-07-17, this file is approximately **5.5 months stale** — new projects, maturity promotions, and archived projects since February will not be captured.
+
+**The recommended command:**
+
+```bash
+# Step 1a: Refresh repo list (no GitHub token required; GITHUB_TOKEN helps with rate limits)
+npm run build:repos
+
+# Step 1b (optional): Also refresh the legacy landscape file if needed
+# npm run fetch:landscape
+
+# Step 2: Full scan against the refreshed list (GitHub token required)
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx
+npx ts-node src/neo.ts \
+  --input input/cncf-expanded-repo-list.json \
+  --queries GetRepoDataExtendedInfo \
+  --dot-project \
+  --analyze \
+  --parallel
+```
+
+**Flags for `build:repos`:**
+
+```bash
+npm run build:repos                                    # full build (landscape + .project)
+npm run build:repos -- --no-dot-project               # landscape only, skip .project HTTP fetches
+npm run build:repos -- --output input/custom.json     # custom output path
+npm run build:repos -- --dry-run                      # print counts, write nothing
+npm run build:repos -- --verbose                      # log each .project repo found
+GITHUB_TOKEN=ghp_xxx npm run build:repos              # with token for rate limit headroom
+```
+
+**Source of truth per script:**
+
+| Script | Landscape source | .project source |
+|--------|-----------------|-----------------|
+| `build-repo-list.ts` | `https://landscape.cncf.io/data/full.json` (.items[] array) | `https://raw.githubusercontent.com/<org>/.project/main/project.yaml` |
+| `fetch-cncf-landscape.ts` | `https://raw.githubusercontent.com/cncf/landscape/master/landscape.yml` | N/A |
+| `--dot-project` flag (neo.ts) | N/A (uses already-built repo list) | GitHub GraphQL `object(expression: "HEAD:project.yaml")` |
+
+**Critical note on dead endpoints:**  
+`https://landscape.cncf.io/data/items.json` now returns HTML (the landscape2 SPA shell). `build-repo-list.ts` explicitly guards against this with a content-type check and a clear error message. Do not use `items.json`.
+
+**Staleness assessment (as of 2026-07-17):**
+
+| File | Last refreshed | Age | Assessment |
+|------|---------------|-----|------------|
+| `input/cncf-full-landscape.json` | 2026-02-02 (commit `1011f44`) | ~5.5 months | **STALE** — run `npm run build:repos` |
+| `input/cncf-expanded-repo-list.json` | Not committed | N/A | Regenerated locally; not tracked in git |
+| `input/test-*.json` | 2026-02-02 | ~5.5 months | Acceptable for testing; refresh when test projects change significantly |
+
+**What `.project` adds vs. landscape alone:**  
+As of the April 2026 run, ~61 of 251 CNCF orgs had a `.project` repo. The `build:repos` script adds repos listed in `repositories[]` of each `project.yaml` that are not already in the landscape — these are often satellite repos (e.g., website, docs, sub-projects) that the landscape tracks as non-primary or omits entirely.
+
+### The `--scan-orgs` flag (separate concern)
+
+`--scan-orgs` is a **runtime** flag on `neo.ts`, not a repo-list utility. When passed, it discovers all repos under each org found in the input data via the GitHub GraphQL `GetOrgRepos` query (paginated). Results land in `base_org_repos`. This is distinct from `build:repos` — it runs during the scan, not before it, and requires a GitHub token.
+
+---
+
+## 5. Graph Layer (LadybugDB)
+
+The graph step is optional but powerful for cross-entity traversal queries.
+
+**Build:**
+```bash
+npm run graph -- --database output/cncf-expanded-repo-list/current/database.db
+# Produces: output/cncf-expanded-repo-list/current/graph.lbug
+```
+
+**Graph schema:**
+- Node tables: `Repository`, `Release`, `ReleaseAsset`, `Workflow`, `CNCFProject`, `Tool`, `ToolCategory`
+- Sources: `base_repositories`, `base_releases`, `base_release_assets`, `base_workflows`, `base_cncf_projects`, `agg_workflow_tools`
+- `Tool` and `ToolCategory` nodes only exist if `agg_workflow_tools` was populated (requires `--analyze` in the collect step)
+
+**Query:**
+```bash
+npm run graph:list                                             # list all built-in queries
+npm run graph:query -- --graph <path> --name graduated-no-signing
+npm run graph:query -- --graph <path> --cypher "MATCH (p:CNCFProject)<-[:BELONGS_TO]-(r:Repository) RETURN p.display_name, count(r) AS repos ORDER BY repos DESC LIMIT 10"
+npm run graph:query -- --graph <path> --file cypher/tool-cooccurrence.cypher
+```
+
+**Standalone Cypher files** in `cypher/`:
+- `graduated-no-signing.cypher`
+- `maturity-tool-adoption.cypher`
+- `tool-cooccurrence.cypher`
+
+**Important:** LadybugDB (`lbug` npm package) uses a directory-based storage format. `npm run graph` removes and recreates `graph.lbug` on each invocation.
+
+---
+
+## 6. Documentation Audit
+
+### Full inventory with recommendations
+
+| Document | Path | Status | Recommendation | Reason |
+|----------|------|--------|----------------|--------|
+| README.md | `/README.md` | Current | **Keep** | Accurate overview, quick-start, script table, architecture summary. Primary entry point. |
+| RUNBOOK.md | `/RUNBOOK.md` | Current | **Keep** | Best operator reference. Full 5-step pipeline with commands, token table, troubleshooting. Complements this PRIMER. |
+| PRIMER.md | `/docs/PRIMER.md` | New | **Keep** | This document. Durable engineering reference. |
+| data-model.md | `docs/data-model.md` | Current | **Keep** | Full table schema reference. Should be updated when new tables are added. Covers `dot_project*` tables. |
+| output-architecture.md | `docs/output-architecture.md` | Current | **Keep** | Good reference for output directory structure and Parquet export strategy. Could merge into PRIMER later. |
+| detection-reference.md | `docs/detection-reference.md` | Current | **Keep** | Canonical catalog of patterns (FTS keywords, REGEXP). Useful for contributors adding new detections. |
+| adding-new-queries.md | `docs/adding-new-queries.md` | Current | **Keep** | Developer how-to for extending the GraphQL query layer. Accurate 5-step workflow. |
+| codegen-guide.md | `docs/codegen-guide.md` | Current | **Keep** | Explains `npm run codegen` / `graphql-codegen` setup. Useful when adding new `.graphql` files. |
+| docs/background/README.md | `docs/background/README.md` | Dated | **Keep (low priority)** | Index to architecture and decisions docs. Not actively maintained but not misleading. |
+| architecture.md | `docs/background/architecture.md` | Dated | **Prune or merge** | Superseded by README and this PRIMER. May describe an older pipeline. Verify before deleting. |
+| decisions.md | `docs/background/decisions.md` | Dated | **Keep** | ADR-style rationale (DuckDB choice, Parquet export, etc.). Historical context; not operational. |
+| duckdb-extensions-strategy.md | `docs/background/duckdb-extensions-strategy.md` | Dated | **Keep** | Rationale for extension install pattern. Useful if the extension strategy changes. |
+| PROJECT-HISTORY.md | `docs/PROJECT-HISTORY.md` | Archival | **Keep (archive)** | Annotated timeline with Mermaid gantt chart. Good historical record; not operational. |
+| project-status-2026-04-27.md | `docs/project-status-2026-04-27.md` | **Stale** | **Prune** | Point-in-time snapshot from April 2026. Content absorbed by README and PROJECT-HISTORY. No new information. |
+| docs/milestones/README.md | `docs/milestones/README.md` | Archival | **Keep (archive)** | Index of milestone planning docs. Historical. |
+| docs/milestones/001–007.md | `docs/milestones/*.md` | Archival | **Keep (archive)** | Planning artifacts for milestones 1–7. Not operational; useful for understanding why decisions were made. |
+| docs/presentations/2026-04-08-tag-sc/ | `docs/presentations/` | Archival | **Keep (archive)** | CNCF TAG Security presentation materials. Reference documents, findings reports, strategy docs. Matt's domain. |
+| docs/superpowers/ | `docs/superpowers/plans/` | **Stale** | **Prune** | `2026-03-30-parallel-workstreams.md` — planning artifact for a sprint that completed. No ongoing operational value. |
+| sql/README.md | `sql/README.md` | Current | **Keep** | Documents the SQL model architecture and numbered execution order. |
+| AGENTS.md | `/AGENTS.md` | Meta | **Keep** | Agent instructions. Not engineering documentation. |
+| CLAUDE.md | `/CLAUDE.md` | Meta | **Keep** | Claude Code instructions. Not engineering documentation. |
+
+### Pruning candidates summary
+
+Files recommended for removal (not deletion yet — review before pruning):
+
+1. **`docs/project-status-2026-04-27.md`** — pure point-in-time snapshot, fully superseded by README + PROJECT-HISTORY.
+2. **`docs/superpowers/plans/2026-03-30-parallel-workstreams.md`** — completed sprint planning artifact.
+3. **`scripts/fetch-cncf-landscape-old.ts`** — explicitly named "old", superseded by `fetch-cncf-landscape.ts`.
+
+Files recommended for merge (consider in a future cleanup):
+
+1. **`docs/background/architecture.md`** — verify content vs. README; if superseded, merge any non-redundant context into PRIMER or delete.
+2. **`docs/output-architecture.md`** — good but overlaps significantly with the RUNBOOK and README output structure sections. Could be absorbed into PRIMER §2 and RUNBOOK §2.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "graph:query": "ts-node src/graph/graph-cli.ts query",
     "graph:list": "ts-node src/graph/graph-cli.ts list",
     "fetch:landscape": "ts-node scripts/fetch-cncf-landscape.ts",
+    "build:repos": "ts-node scripts/build-repo-list.ts",
     "codegen": "graphql-codegen --config codegen.ts",
     "postinstall": "npm run codegen",
     "lint": "npx eslint src/",

--- a/scripts/build-repo-list.ts
+++ b/scripts/build-repo-list.ts
@@ -1,0 +1,498 @@
+/**
+ * build-repo-list.ts
+ *
+ * Builds a reproducible, deduplicated repository list for the supply-chain-security-collector
+ * by UNION-ing two sources:
+ *
+ *   (a) CNCF landscape repos — from https://landscape.cncf.io/data/full.json (.items[])
+ *       The full.json endpoint returns real application/json. Do NOT use items.json —
+ *       that URL now returns the landscape2 SPA shell (HTML).
+ *
+ *   (b) .project repositories[] — for each CNCF project, fetches
+ *       https://raw.githubusercontent.com/<org>/.project/main/project.yaml
+ *       and adds any repos not already in the landscape. Projects without a .project
+ *       repo (404) are skipped gracefully.
+ *
+ * Each output entry carries a `source` provenance label: "landscape", "dot-project", or "both".
+ * Deduplication is on nameWithOwner (owner/name, case-insensitive).
+ *
+ * Usage:
+ *   npm run build:repos                                       # fetch live, write to input/
+ *   npm run build:repos -- --output input/my-custom.json     # custom output path
+ *   npm run build:repos -- --no-dot-project                  # landscape only (no .project fetch)
+ *   npm run build:repos -- --dry-run                         # print summary, don't write files
+ *   npm run build:repos -- --verbose                         # log per-project detail
+ *
+ * Environment (optional):
+ *   GITHUB_TOKEN or GITHUB_PERSONAL_ACCESS_TOKEN  — reduces rate-limiting on .project fetches.
+ *   Without a token, unauthenticated raw.githubusercontent.com GETs are used.
+ */
+
+import fetch from 'node-fetch';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+
+// ============================================================================
+// CLI ARGS
+// ============================================================================
+
+function parseArgs(): {
+  output: string;
+  dotProject: boolean;
+  dryRun: boolean;
+  verbose: boolean;
+} {
+  const args = process.argv.slice(2);
+  let output = path.join(__dirname, '../input/cncf-expanded-repo-list.json');
+  let dotProject = true;
+  let dryRun = false;
+  let verbose = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--output' && args[i + 1]) {
+      output = args[++i];
+    } else if (args[i] === '--no-dot-project') {
+      dotProject = false;
+    } else if (args[i] === '--dry-run') {
+      dryRun = true;
+    } else if (args[i] === '--verbose' || args[i] === '-v') {
+      verbose = true;
+    }
+  }
+
+  return { output, dotProject, dryRun, verbose };
+}
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+// Matches src/config.ts ProjectMetadata + provenance extension
+interface RepoRef {
+  owner: string;
+  name: string;
+  primary: boolean;
+  branch?: string;
+}
+
+interface ProjectMetadataWithSource {
+  project_name: string;
+  display_name?: string;
+  description?: string;
+  repos: RepoRef[];
+  maturity?: 'graduated' | 'incubating' | 'sandbox' | 'archived';
+  category?: string;
+  subcategory?: string;
+  date_accepted?: string;
+  date_incubating?: string;
+  date_graduated?: string;
+  date_archived?: string;
+  homepage_url?: string;
+  repo_url?: string;        // primary repo URL (for compatibility with existing pipeline)
+  package_manager_url?: string;
+  docker_url?: string;
+  documentation_url?: string;
+  blog_url?: string;
+  url_for_bestpractices?: string;
+  clomonitor_name?: string;
+  has_security_audits?: boolean;
+  security_audit_count?: number;
+  latest_audit_date?: string;
+  latest_audit_vendor?: string;
+  crunchbase?: string;
+  twitter?: string;
+  parent_project?: string;
+  tag_associations?: string;
+  annual_review_date?: string;
+  annual_review_url?: string;
+  license?: string;
+  default_branch?: string;
+  dev_stats_url?: string;
+  // Provenance (extension beyond base ProjectMetadata)
+  source: 'landscape' | 'dot-project' | 'both';
+  dot_project_repos?: string[];  // net-new repos added from .project
+}
+
+// landscape.cncf.io/data/full.json item shape
+// full.json uses a flat structure (no nested `extra`, no `additional_repos`).
+interface FullJsonRepository {
+  url: string;
+  primary?: boolean;
+  branch?: string;
+}
+
+interface FullJsonAudit {
+  date?: string;
+  type?: string;
+  url?: string;
+  vendor?: string;
+}
+
+interface FullJsonSummary {
+  business_use_case?: string;
+  integrations?: string;
+  personas?: string[];
+  release_rate?: string;
+  tags?: string[];
+  use_case?: string;
+}
+
+interface FullJsonItem {
+  // Core identity
+  id: string;
+  name: string;
+  category: string;
+  subcategory: string;
+  maturity?: 'graduated' | 'incubating' | 'sandbox' | 'archived';
+  // Repos
+  repositories?: FullJsonRepository[];
+  // URLs
+  homepage_url?: string;
+  website?: string;
+  crunchbase_url?: string;
+  twitter_url?: string;
+  devstats_url?: string;
+  mailing_list_url?: string;
+  slack_url?: string;
+  artwork_url?: string;
+  blog_url?: string;
+  // CNCF dates
+  accepted_at?: string;
+  incubating_at?: string;
+  graduated_at?: string;
+  archived_at?: string;
+  // Security
+  audits?: FullJsonAudit[];
+  // CLOMonitor
+  clomonitor_name?: string;
+  lfx_slug?: string;
+  // Tags
+  oss?: boolean;
+  // Summary fields
+  summary?: FullJsonSummary;
+  // Extra fields we may not need but shouldn't error on
+  [key: string]: unknown;
+}
+
+interface FullJsonResponse {
+  items?: FullJsonItem[];
+  [key: string]: unknown;
+}
+
+// .project project.yaml shape (what we need)
+interface DotProjectYaml {
+  schema_version?: string;
+  slug?: string;
+  name?: string;
+  description?: string;
+  repositories?: string[];
+  maturity_log?: Array<{ phase?: string; date?: string; issue?: string }>;
+}
+
+// ============================================================================
+// LANDSCAPE SOURCE
+// ============================================================================
+
+// IMPORTANT: Use full.json, NOT items.json.
+// items.json returns HTML (landscape2 SPA shell) — content-type: text/html.
+// full.json returns content-type: application/json with an .items[] array.
+const FULL_JSON_URL = 'https://landscape.cncf.io/data/full.json';
+
+function repoFromUrl(url: string, primary: boolean, branch?: string): RepoRef | null {
+  if (!url) return null;
+  const match = url.match(/github\.com\/([^/]+)\/([^/#? ]+)/);
+  if (!match) return null;
+  return {
+    owner: match[1],
+    name: match[2].replace(/\.git$/, ''),
+    primary,
+    branch,
+  };
+}
+
+async function fetchLandscapeProjects(): Promise<Map<string, ProjectMetadataWithSource>> {
+  console.log(`\nFetching landscape: ${FULL_JSON_URL}`);
+  const resp = await fetch(FULL_JSON_URL);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch full.json: ${resp.status} ${resp.statusText}`);
+  }
+  const contentType = resp.headers.get('content-type') || '';
+  if (contentType.includes('text/html')) {
+    throw new Error(
+      `full.json returned text/html — the URL may have changed.\n` +
+      `  items.json now returns the landscape2 SPA shell.\n` +
+      `  Current URL: ${FULL_JSON_URL}\n` +
+      `  Check https://landscape.cncf.io for the correct data endpoint.`
+    );
+  }
+
+  const data = (await resp.json()) as FullJsonResponse;
+  const items: FullJsonItem[] = Array.isArray(data.items) ? data.items : [];
+
+  if (items.length === 0) {
+    const topKeys = Object.keys(data).join(', ');
+    throw new Error(
+      `full.json returned 0 items. Top-level keys: [${topKeys}].\n` +
+      `  The response shape may have changed.`
+    );
+  }
+
+  console.log(`  Loaded ${items.length} landscape items`);
+
+  const byProjectName = new Map<string, ProjectMetadataWithSource>();
+
+  for (const item of items) {
+    // Only CNCF projects have a maturity field
+    if (!item.maturity) continue;
+
+    const repos: RepoRef[] = [];
+    for (const r of item.repositories || []) {
+      const ref = repoFromUrl(r.url, r.primary === true, r.branch);
+      if (ref) repos.push(ref);
+    }
+    if (repos.length === 0) continue;
+
+    const audits = item.audits || [];
+    const primaryRepo = repos.find(r => r.primary);
+    const project_name = item.name.replace(/[^a-zA-Z0-9\-_. ]/g, '');
+
+    const metadata: ProjectMetadataWithSource = {
+      project_name,
+      display_name: item.name,
+      description: item.summary?.use_case,
+      repos,
+      maturity: item.maturity,
+      category: item.category,
+      subcategory: item.subcategory,
+      date_accepted: item.accepted_at,
+      date_incubating: item.incubating_at,
+      date_graduated: item.graduated_at,
+      date_archived: item.archived_at,
+      homepage_url: item.homepage_url || item.website,
+      repo_url: primaryRepo ? `https://github.com/${primaryRepo.owner}/${primaryRepo.name}` : undefined,
+      blog_url: item.blog_url,
+      dev_stats_url: item.devstats_url,
+      clomonitor_name: item.clomonitor_name,
+      has_security_audits: audits.length > 0,
+      security_audit_count: audits.length,
+      latest_audit_date: audits.length > 0 ? audits[audits.length - 1].date : undefined,
+      latest_audit_vendor: audits.length > 0 ? audits[audits.length - 1].vendor : undefined,
+      crunchbase: item.crunchbase_url,
+      twitter: item.twitter_url,
+      source: 'landscape',
+    };
+
+    byProjectName.set(project_name.toLowerCase(), metadata);
+  }
+
+  console.log(`  Extracted ${byProjectName.size} CNCF projects from landscape`);
+  return byProjectName;
+}
+
+// ============================================================================
+// .PROJECT SOURCE
+// ============================================================================
+
+async function fetchDotProject(
+  org: string,
+  projectName: string,
+  githubToken: string | undefined,
+  verbose: boolean
+): Promise<DotProjectYaml | null> {
+  const headers: Record<string, string> = {
+    'User-Agent': 'supply-chain-security-collector/1.0',
+  };
+  // Token not needed for public repos on raw.githubusercontent.com but helps with rate limits
+  if (githubToken) {
+    headers['Authorization'] = `Bearer ${githubToken}`;
+  }
+
+  // Try main branch first, then master
+  for (const branch of ['main', 'master']) {
+    const url = `https://raw.githubusercontent.com/${org}/.project/${branch}/project.yaml`;
+    try {
+      const resp = await fetch(url, { headers });
+      if (resp.status === 404) continue;
+      if (resp.status === 403 || resp.status === 429) {
+        console.warn(`  [rate-limited] ${org}/.project (HTTP ${resp.status}) — set GITHUB_TOKEN to raise limits`);
+        return null;
+      }
+      if (!resp.ok) {
+        if (verbose) console.log(`    [${projectName}] ${org}/.project (${branch}): HTTP ${resp.status}`);
+        return null;
+      }
+      const text = await resp.text();
+      try {
+        const parsed = yaml.parse(text) as DotProjectYaml;
+        if (parsed && Array.isArray(parsed.repositories) && parsed.repositories.length > 0) {
+          return parsed;
+        }
+        return null;  // no repositories field or empty
+      } catch {
+        if (verbose) console.log(`    [${projectName}] YAML parse error for ${org}/.project`);
+        return null;
+      }
+    } catch (err) {
+      if (verbose) {
+        console.log(`    [${projectName}] fetch error: ${err instanceof Error ? err.message : err}`);
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+// ============================================================================
+// DEDUP HELPERS
+// ============================================================================
+
+function nwo(owner: string, name: string): string {
+  return `${owner}/${name}`.toLowerCase();
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+async function main() {
+  const { output, dotProject: fetchDotProjectData, dryRun, verbose } = parseArgs();
+
+  const githubToken =
+    process.env.GITHUB_TOKEN ||
+    process.env.GITHUB_PERSONAL_ACCESS_TOKEN ||
+    undefined;
+
+  console.log('');
+  console.log('CNCF Expanded Repo List Builder');
+  console.log('='.repeat(50));
+  console.log(`Sources: landscape (full.json)${fetchDotProjectData ? ' + .project repos' : ''}`);
+  if (githubToken) {
+    console.log('  GitHub token: set (rate limits raised)');
+  } else {
+    console.log('  GitHub token: not set (unauthenticated; set GITHUB_TOKEN to raise rate limits)');
+  }
+  console.log(`Output:  ${dryRun ? '[dry-run, no write]' : output}`);
+  console.log('');
+
+  // ── Step 1: Fetch landscape ──────────────────────────────────────────────
+  const projectsByName = await fetchLandscapeProjects();
+
+  // Build global nameWithOwner registry for dedup
+  const nwoRegistry = new Map<string, string>();  // nwo -> project_name
+  for (const [pname, meta] of projectsByName) {
+    for (const repo of meta.repos) {
+      nwoRegistry.set(nwo(repo.owner, repo.name), pname);
+    }
+  }
+
+  let landscapeRepoCount = 0;
+  for (const meta of projectsByName.values()) landscapeRepoCount += meta.repos.length;
+  console.log(`  Landscape repos: ${landscapeRepoCount} across ${projectsByName.size} projects`);
+
+  // ── Step 2: .project enrichment ──────────────────────────────────────────
+  let dotProjectFound = 0;
+  let dotProjectSkipped = 0;
+  let dotProjectAdded = 0;
+
+  if (fetchDotProjectData) {
+    console.log('\nFetching .project repos for CNCF projects...');
+    if (!githubToken) {
+      console.log('  (no GITHUB_TOKEN — using unauthenticated GETs; set token to avoid rate limits)');
+    }
+    console.log('  (projects without a .project repo are skipped gracefully)\n');
+
+    const projectList = Array.from(projectsByName.values());
+
+    // Process in small concurrent batches to avoid hammering GitHub
+    const BATCH_SIZE = 8;
+    const BATCH_DELAY_MS = 600;
+
+    for (let i = 0; i < projectList.length; i += BATCH_SIZE) {
+      const batch = projectList.slice(i, i + BATCH_SIZE);
+
+      await Promise.all(batch.map(async (meta) => {
+        const primaryRepo = meta.repos.find(r => r.primary) || meta.repos[0];
+        if (!primaryRepo) return;
+        const org = primaryRepo.owner;
+
+        const dotData = await fetchDotProject(org, meta.display_name || meta.project_name, githubToken, verbose);
+        if (!dotData) {
+          dotProjectSkipped++;
+          return;
+        }
+
+        dotProjectFound++;
+        const newRepos: string[] = [];
+
+        for (const repoUrl of dotData.repositories || []) {
+          const r = repoFromUrl(repoUrl, false);
+          if (!r) continue;
+          const key = nwo(r.owner, r.name);
+
+          if (!nwoRegistry.has(key)) {
+            // Net-new repo not captured by landscape — add to this project
+            meta.repos.push({ ...r, primary: false });
+            nwoRegistry.set(key, meta.project_name.toLowerCase());
+            newRepos.push(`${r.owner}/${r.name}`);
+            dotProjectAdded++;
+            if (verbose) {
+              console.log(`  + ${r.owner}/${r.name} (${meta.display_name} via .project)`);
+            }
+          }
+        }
+
+        if (newRepos.length > 0) {
+          meta.dot_project_repos = newRepos;
+          meta.source = 'both';
+        }
+      }));
+
+      if (i + BATCH_SIZE < projectList.length) {
+        await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+      }
+
+      const done = Math.min(i + BATCH_SIZE, projectList.length);
+      process.stdout.write(`\r  Progress: ${done}/${projectList.length} projects  `);
+    }
+    console.log('\n');
+
+    const enrichedProjects = Array.from(projectsByName.values()).filter(m => m.source === 'both');
+    console.log('.project summary:');
+    console.log(`  Projects with .project repo found:  ${dotProjectFound}`);
+    console.log(`    - contributed extra repos:        ${enrichedProjects.length} projects, ${dotProjectAdded} net-new repos`);
+    console.log(`  Projects without .project (404/skipped): ${dotProjectSkipped}`);
+  }
+
+  // ── Step 3: Final output ──────────────────────────────────────────────────
+  const finalProjects = Array.from(projectsByName.values());
+
+  const allNwo = new Set<string>();
+  for (const meta of finalProjects) {
+    for (const repo of meta.repos) {
+      allNwo.add(nwo(repo.owner, repo.name));
+    }
+  }
+
+  console.log('\nFinal counts:');
+  console.log(`  Projects:               ${finalProjects.length}`);
+  console.log(`  Total unique repos:     ${allNwo.size} (deduped on owner/name)`);
+  console.log(`    landscape-only:       ${finalProjects.filter(m => m.source === 'landscape').length} projects`);
+  console.log(`    enriched by .project: ${finalProjects.filter(m => m.source === 'both').length} projects`);
+
+  if (!dryRun) {
+    const outDir = path.dirname(output);
+    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(output, JSON.stringify(finalProjects, null, 2) + '\n');
+    console.log(`\nWritten: ${output}`);
+  } else {
+    console.log('\n[dry-run] No files written.');
+  }
+
+  console.log('\nDone.\n');
+}
+
+main().catch(err => {
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/test-dot-project-duckdb.ts
+++ b/scripts/test-dot-project-duckdb.ts
@@ -1,0 +1,266 @@
+/**
+ * test-dot-project-duckdb.ts
+ *
+ * Validates that parseDotProject output actually lands in DuckDB correctly.
+ * Uses an in-memory DuckDB instance — no token, no network required.
+ *
+ * Usage:
+ *   npx ts-node scripts/test-dot-project-duckdb.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { parseDotProject, mergeDotProjectResults } from '../src/normalizers/DotProjectNormalizer';
+import { installAndLoadExtensions } from '../src/duckdb-extensions';
+
+// Fixture: real open-telemetry data from test-dot-project-parse.ts
+const OTEL_YAML = `
+schema_version: "1.0.0"
+slug: "opentelemetry"
+name: "OpenTelemetry"
+description: "High-quality, ubiquitous, and portable telemetry to enable effective observability"
+type: "project"
+project_lead: "alolita"
+maturity_log:
+  - phase: "graduated"
+    date: "2019-05-07T00:00:00Z"
+    issue: "https://github.com/cncf/toc/issues/2152"
+repositories:
+  - "https://github.com/open-telemetry/community"
+  - "https://github.com/open-telemetry/opentelemetry-specification"
+website: "https://opentelemetry.io/"
+security:
+  policy:
+    path: "https://github.com/open-telemetry/.github/blob/main/SECURITY.md"
+  contact:
+    advisory_url: "https://github.com/open-telemetry/opentelemetry.io/security/advisories/new"
+landscape:
+  category: "Observability and Analysis"
+  subcategory: "Observability"
+`;
+
+const KUBERNETES_YAML = `
+schema_version: "1.0.0"
+slug: "kubernetes"
+name: "Kubernetes"
+description: "Container orchestration"
+type: "platform"
+project_lead:
+  - "thockin"
+  - "kubernetes/sig-leads"
+maturity_log:
+  - phase: "graduated"
+    date: "2018-03-06T00:00:00Z"
+    issue: "https://github.com/cncf/toc/issues/999"
+repositories:
+  - "https://github.com/kubernetes/kubernetes"
+audits:
+  - date: 2019-08-06T00:00:00Z
+    type: "security"
+    url: "https://example.com/audit1"
+security:
+  contact:
+    email: "security@kubernetes.io"
+`;
+
+const DOT_PROJECT_SCHEMAS = {
+    dot_project: `
+        org TEXT NOT NULL,
+        source_url TEXT NOT NULL,
+        schema_version TEXT,
+        slug TEXT,
+        name TEXT,
+        description TEXT,
+        type TEXT,
+        project_lead TEXT,
+        repository_count INTEGER,
+        website TEXT,
+        current_maturity TEXT,
+        current_maturity_date TEXT,
+        audit_count INTEGER,
+        security_policy_path TEXT,
+        security_threat_model_path TEXT,
+        security_contact_email TEXT,
+        security_advisory_url TEXT,
+        landscape_category TEXT,
+        landscape_subcategory TEXT,
+        package_managers_json TEXT,
+        fetched_at TIMESTAMP
+    `,
+    dot_project_repositories: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        repo_url TEXT NOT NULL,
+        repo_owner TEXT,
+        repo_name TEXT
+    `,
+    dot_project_maturity_log: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        phase TEXT,
+        date TEXT,
+        issue TEXT
+    `,
+    dot_project_audits: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        date TEXT,
+        type TEXT,
+        url TEXT
+    `,
+} as const;
+
+async function main() {
+    console.log('DotProjectNormalizer → DuckDB landing test');
+    console.log('='.repeat(50));
+
+    // Parse fixtures
+    const r1 = parseDotProject('open-telemetry', OTEL_YAML,
+        'https://github.com/open-telemetry/.project/blob/HEAD/project.yaml');
+    const r2 = parseDotProject('kubernetes', KUBERNETES_YAML,
+        'https://github.com/kubernetes/.project/blob/HEAD/project.yaml');
+
+    if (!r1 || !r2) {
+        console.error('FAIL: parseDotProject returned null for a fixture');
+        process.exit(1);
+    }
+
+    const merged = mergeDotProjectResults([r1, r2]);
+    console.log(`Parsed: ${merged.dot_project.length} projects, ${merged.dot_project_repositories.length} repos`);
+
+    // Write to a temp DuckDB
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dot-project-test-'));
+    const dbPath = path.join(tmpDir, 'test.db');
+    const db = await DuckDBInstance.create(dbPath);
+    const con = await db.connect();
+
+    try {
+        await installAndLoadExtensions(con);
+
+        // Write each table using the same pattern as writeDotProjectArtifacts
+        for (const [tableName, data] of [
+            ['dot_project', merged.dot_project],
+            ['dot_project_repositories', merged.dot_project_repositories],
+            ['dot_project_maturity_log', merged.dot_project_maturity_log],
+            ['dot_project_audits', merged.dot_project_audits],
+        ] as const) {
+            const schema = DOT_PROJECT_SCHEMAS[tableName];
+            if (data.length > 0) {
+                const tempPath = path.join(tmpDir, `temp_${tableName}.json`);
+                fs.writeFileSync(tempPath, JSON.stringify(data));
+                await con.run(`
+                    CREATE TABLE ${tableName} AS
+                    SELECT * FROM read_json('${tempPath}', format='array', auto_detect=true, union_by_name=true)
+                `);
+                fs.unlinkSync(tempPath);
+            } else {
+                await con.run(`CREATE TABLE ${tableName} (${schema})`);
+            }
+            console.log(`  Created: ${tableName} (${(data as unknown[]).length} rows)`);
+        }
+
+        // Query and validate
+        console.log('\n── dot_project ──');
+        const dpResult = await con.run(`
+            SELECT org, slug, name, current_maturity, repository_count, audit_count,
+                   security_advisory_url IS NOT NULL AS has_advisory,
+                   security_contact_email,
+                   landscape_category
+            FROM dot_project
+            ORDER BY org
+        `);
+        const dpRows = await dpResult.getRows();
+        for (const row of dpRows) {
+            console.log(row);
+        }
+
+        console.log('\n── dot_project_repositories ──');
+        const repoResult = await con.run(`
+            SELECT org, repo_owner, repo_name, position
+            FROM dot_project_repositories
+            ORDER BY org, position
+        `);
+        const repoRows = await repoResult.getRows();
+        for (const row of repoRows) {
+            console.log(row);
+        }
+
+        console.log('\n── dot_project_maturity_log ──');
+        const matResult = await con.run(`
+            SELECT org, phase, date, position
+            FROM dot_project_maturity_log
+            ORDER BY org, position
+        `);
+        const matRows = await matResult.getRows();
+        for (const row of matRows) {
+            console.log(row);
+        }
+
+        console.log('\n── dot_project_audits ──');
+        const auditResult = await con.run(`
+            SELECT org, type, url, position
+            FROM dot_project_audits
+            ORDER BY org, position
+        `);
+        const auditRows = await auditResult.getRows();
+        for (const row of auditRows) {
+            console.log(row);
+        }
+
+        // Assertions on query results
+        console.log('\n── Assertions ──');
+
+        function assert(cond: boolean, msg: string) {
+            if (!cond) { console.error(`  FAIL: ${msg}`); process.exitCode = 1; }
+            else console.log(`  PASS: ${msg}`);
+        }
+
+        assert(dpRows.length === 2, `dot_project has 2 rows (got ${dpRows.length})`);
+
+        // Row ordering: open-telemetry < kubernetes alphabetically
+        const otelRow = dpRows.find(r => r[0] === 'open-telemetry');
+        const k8sRow = dpRows.find(r => r[0] === 'kubernetes');
+
+        assert(otelRow !== undefined, 'open-telemetry row exists');
+        assert(k8sRow !== undefined, 'kubernetes row exists');
+
+        if (otelRow) {
+            assert(otelRow[1] === 'opentelemetry', `otel slug = opentelemetry (got ${otelRow[1]})`);
+            assert(otelRow[3] === 'graduated', `otel maturity = graduated (got ${otelRow[3]})`);
+            assert(Number(otelRow[4]) === 2, `otel repository_count = 2 (got ${otelRow[4]})`);
+            assert(otelRow[6] === true, 'otel has_advisory = true');
+        }
+
+        if (k8sRow) {
+            assert(k8sRow[1] === 'kubernetes', `k8s slug = kubernetes (got ${k8sRow[1]})`);
+            assert(Number(k8sRow[5]) === 1, `k8s audit_count = 1 (got ${k8sRow[5]})`);
+            assert(k8sRow[7] === 'security@kubernetes.io', `k8s security_contact_email set`);
+        }
+
+        assert(repoRows.length === 3, `dot_project_repositories has 3 rows (got ${repoRows.length})`);
+        assert(matRows.length === 2, `dot_project_maturity_log has 2 rows (got ${matRows.length})`);
+        assert(auditRows.length === 1, `dot_project_audits has 1 row (got ${auditRows.length})`);
+
+        await con.run('CHECKPOINT');
+    } finally {
+        try { con.closeSync(); } catch { /* ignore */ }
+    }
+
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true });
+
+    const exitCode = process.exitCode ?? 0;
+    console.log(`\n${'='.repeat(50)}`);
+    if (exitCode === 0) {
+        console.log('All DuckDB landing tests passed.');
+    } else {
+        console.error('Some DuckDB landing tests FAILED.');
+    }
+}
+
+main().catch(err => {
+    console.error('Error:', err);
+    process.exit(1);
+});

--- a/scripts/test-dot-project-parse.ts
+++ b/scripts/test-dot-project-parse.ts
@@ -1,0 +1,259 @@
+/**
+ * test-dot-project-parse.ts
+ *
+ * Standalone validation script for DotProjectNormalizer.
+ * Runs without a GitHub token — tests the YAML parse and normalization logic
+ * against the real open-telemetry/.project/project.yaml fetched via
+ * unauthenticated raw.githubusercontent.com.
+ *
+ * Usage:
+ *   npx ts-node scripts/test-dot-project-parse.ts
+ *
+ * Also validates the example from the .project schema:
+ *   ~/gh/f/cncf/automation/utilities/dot-project/example/project.yaml
+ */
+
+import * as https from 'https';
+import { parseDotProject, mergeDotProjectResults, getDotProjectStats } from '../src/normalizers/DotProjectNormalizer';
+
+// ---------------------------------------------------------------------------
+// Inline example fixture (mirrors the schema example — kubernetes)
+// ---------------------------------------------------------------------------
+const KUBERNETES_EXAMPLE_YAML = `
+schema_version: "1.0.0"
+slug: "kubernetes"
+name: "Kubernetes"
+description: "Kubernetes is an open-source system for automating deployment, scaling, and management of containerized applications."
+type: "platform"
+project_lead:
+  - "thockin"
+  - "kubernetes/sig-leads"
+maturity_log:
+  - phase: "sandbox"
+    date: 2016-03-10T00:00:00Z
+    issue: "https://github.com/cncf/toc/issues/123"
+  - phase: "incubating"
+    date: 2017-03-01T00:00:00Z
+    issue: "https://github.com/cncf/toc/issues/123"
+  - phase: "graduated"
+    date: 2018-03-06T00:00:00Z
+    issue: "https://github.com/cncf/toc/issues/123"
+repositories:
+  - "https://github.com/kubernetes/kubernetes"
+  - "https://github.com/kubernetes/kubectl"
+  - "https://github.com/kubernetes/client-go"
+  - "https://github.com/kubernetes/api"
+website: "https://kubernetes.io"
+audits:
+  - date: 2019-08-06T00:00:00Z
+    type: "security"
+    url: "https://example.com/audit1"
+  - date: 2021-05-17T00:00:00Z
+    type: "security"
+    url: "https://example.com/audit2"
+security:
+  policy:
+    path: "https://github.com/kubernetes/kubernetes/blob/master/SECURITY.md"
+  threat_model:
+    path: "https://github.com/kubernetes/community/blob/master/sig-security/threat-model.md"
+  contact:
+    email: security@kubernetes.io
+    advisory_url: "https://github.com/kubernetes/kubernetes/security/advisories/new"
+landscape:
+  category: "Orchestration & Management"
+  subcategory: "Scheduling & Orchestration"
+package_managers:
+  homebrew: "kubernetes-cli"
+  chocolatey: "kubernetes-cli"
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fetchUrl(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    https.get(url, { timeout: 10000 }, (res) => {
+      if (res.statusCode === 404) {
+        reject(new Error(`HTTP 404: ${url}`));
+        return;
+      }
+      let data = '';
+      res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+      res.on('end', () => resolve(data));
+      res.on('error', reject);
+    }).on('error', reject).on('timeout', () => reject(new Error(`Timeout: ${url}`)));
+  });
+}
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`  PASS: ${msg}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Inline kubernetes example (no network)
+// ---------------------------------------------------------------------------
+
+function testKubernetesExample(): void {
+  console.log('\n══ Test 1: Kubernetes example (inline fixture, no network) ══\n');
+
+  const result = parseDotProject(
+    'kubernetes',
+    KUBERNETES_EXAMPLE_YAML,
+    'https://github.com/kubernetes/.project/blob/HEAD/project.yaml'
+  );
+
+  if (!result) {
+    console.error('FAIL: parseDotProject returned null for kubernetes example');
+    process.exitCode = 1;
+    return;
+  }
+
+  const dp = result.dot_project[0];
+  console.log('dot_project record:');
+  console.log(JSON.stringify(dp, null, 2));
+
+  console.log('\nAssertions:');
+  assert(dp.org === 'kubernetes', `org = 'kubernetes' (got '${dp.org}')`);
+  assert(dp.slug === 'kubernetes', `slug = 'kubernetes' (got '${dp.slug}')`);
+  assert(dp.name === 'Kubernetes', `name = 'Kubernetes' (got '${dp.name}')`);
+  assert(dp.type === 'platform', `type = 'platform' (got '${dp.type}')`);
+  assert(dp.current_maturity === 'graduated', `current_maturity = 'graduated' (got '${dp.current_maturity}')`);
+  assert(dp.project_lead === 'thockin, kubernetes/sig-leads', `project_lead = 'thockin, kubernetes/sig-leads' (got '${dp.project_lead}')`);
+  assert(dp.repository_count === 4, `repository_count = 4 (got ${dp.repository_count})`);
+  assert(dp.audit_count === 2, `audit_count = 2 (got ${dp.audit_count})`);
+  assert(dp.security_policy_path === 'https://github.com/kubernetes/kubernetes/blob/master/SECURITY.md', 'security_policy_path set');
+  assert(dp.security_threat_model_path !== null, 'security_threat_model_path set');
+  assert(dp.security_contact_email === 'security@kubernetes.io', `security_contact_email set (got '${dp.security_contact_email}')`);
+  assert(dp.security_advisory_url !== null, 'security_advisory_url set');
+  assert(dp.landscape_category === 'Orchestration & Management', `landscape_category set (got '${dp.landscape_category}')`);
+  assert(dp.landscape_subcategory === 'Scheduling & Orchestration', `landscape_subcategory set`);
+  assert(dp.package_managers_json !== null, 'package_managers_json set');
+
+  console.log('\ndot_project_repositories:');
+  console.log(JSON.stringify(result.dot_project_repositories, null, 2));
+  assert(result.dot_project_repositories.length === 4, `4 repositories (got ${result.dot_project_repositories.length})`);
+  assert(result.dot_project_repositories[0].repo_owner === 'kubernetes', 'first repo owner = kubernetes');
+  assert(result.dot_project_repositories[0].repo_name === 'kubernetes', 'first repo name = kubernetes');
+
+  console.log('\ndot_project_maturity_log:');
+  console.log(JSON.stringify(result.dot_project_maturity_log, null, 2));
+  assert(result.dot_project_maturity_log.length === 3, `3 maturity entries (got ${result.dot_project_maturity_log.length})`);
+  assert(result.dot_project_maturity_log[0].phase === 'sandbox', 'first phase = sandbox');
+  assert(result.dot_project_maturity_log[2].phase === 'graduated', 'last phase = graduated');
+
+  console.log('\ndot_project_audits:');
+  console.log(JSON.stringify(result.dot_project_audits, null, 2));
+  assert(result.dot_project_audits.length === 2, `2 audits (got ${result.dot_project_audits.length})`);
+  assert(result.dot_project_audits[0].type === 'security', `audit[0].type = security`);
+
+  console.log('\n' + getDotProjectStats(result));
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Real open-telemetry/.project via unauthenticated raw fetch
+// ---------------------------------------------------------------------------
+
+async function testOpenTelemetry(): Promise<void> {
+  console.log('\n══ Test 2: open-telemetry/.project (live unauthenticated fetch) ══\n');
+
+  const url = 'https://raw.githubusercontent.com/open-telemetry/.project/main/project.yaml';
+  let yamlText: string;
+  try {
+    yamlText = await fetchUrl(url);
+    console.log(`Fetched ${yamlText.length} bytes from ${url}`);
+  } catch (err) {
+    console.warn(`  SKIP: network unavailable or 404 (${err instanceof Error ? err.message : err})`);
+    return;
+  }
+
+  const result = parseDotProject(
+    'open-telemetry',
+    yamlText,
+    'https://github.com/open-telemetry/.project/blob/HEAD/project.yaml'
+  );
+
+  if (!result) {
+    console.error('FAIL: parseDotProject returned null for open-telemetry');
+    process.exitCode = 1;
+    return;
+  }
+
+  const dp = result.dot_project[0];
+  console.log('dot_project record:');
+  console.log(JSON.stringify(dp, null, 2));
+
+  console.log('\nAssertions:');
+  assert(dp.org === 'open-telemetry', `org = 'open-telemetry' (got '${dp.org}')`);
+  assert(dp.slug === 'opentelemetry', `slug = 'opentelemetry' (got '${dp.slug}')`);
+  assert(dp.name === 'OpenTelemetry', `name = 'OpenTelemetry' (got '${dp.name}')`);
+  assert(dp.current_maturity === 'graduated', `current_maturity = 'graduated' (got '${dp.current_maturity}')`);
+  assert(dp.security_policy_path !== null, 'security_policy_path set');
+  assert(dp.security_advisory_url !== null, 'security_advisory_url set');
+  assert(dp.landscape_category === 'Observability and Analysis', `landscape_category set (got '${dp.landscape_category}')`);
+  assert(result.dot_project_repositories.length >= 1, `at least 1 repository (got ${result.dot_project_repositories.length})`);
+  assert(result.dot_project_repositories[0].repo_owner === 'open-telemetry', 'first repo owner = open-telemetry');
+  assert(result.dot_project_maturity_log.length >= 1, `at least 1 maturity_log entry (got ${result.dot_project_maturity_log.length})`);
+
+  console.log('\n' + getDotProjectStats(result));
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: null on invalid YAML
+// ---------------------------------------------------------------------------
+
+function testInvalidYaml(): void {
+  console.log('\n══ Test 3: Invalid YAML returns null ══\n');
+  const result = parseDotProject('test-org', ': this is not valid yaml: [', 'test-url');
+  assert(result === null, 'invalid YAML returns null');
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: merge multiple results
+// ---------------------------------------------------------------------------
+
+function testMerge(): void {
+  console.log('\n══ Test 4: mergeDotProjectResults ══\n');
+
+  const r1 = parseDotProject('kubernetes', KUBERNETES_EXAMPLE_YAML, 'test-url-1');
+  const r2 = null; // parse failure / missing repo
+  const r3 = parseDotProject('kubernetes', KUBERNETES_EXAMPLE_YAML, 'test-url-3'); // same org, 2nd entry
+
+  const merged = mergeDotProjectResults([r1, r2, r3]);
+  assert(merged.dot_project.length === 2, `merged dot_project has 2 rows (got ${merged.dot_project.length})`);
+  assert(merged.dot_project_repositories.length === 8, `merged repos has 8 rows (got ${merged.dot_project_repositories.length})`);
+  assert(merged.dot_project_maturity_log.length === 6, `merged maturity_log has 6 rows (got ${merged.dot_project_maturity_log.length})`);
+  assert(merged.dot_project_audits.length === 4, `merged audits has 4 rows (got ${merged.dot_project_audits.length})`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log('DotProjectNormalizer — parse validation');
+  console.log('='.repeat(50));
+
+  testKubernetesExample();
+  await testOpenTelemetry();
+  testInvalidYaml();
+  testMerge();
+
+  const exitCode = process.exitCode ?? 0;
+  console.log(`\n${'='.repeat(50)}`);
+  if (exitCode === 0) {
+    console.log('All tests passed.');
+  } else {
+    console.error(`${exitCode} test(s) failed.`);
+  }
+}
+
+main().catch(err => {
+  console.error('Test runner error:', err);
+  process.exit(1);
+});

--- a/src/ArtifactWriter.ts
+++ b/src/ArtifactWriter.ts
@@ -7,14 +7,21 @@ import chalk from 'chalk';
 import type { GetRepoDataArtifactsQuery, GetRepoDataExtendedInfoQuery } from './generated/graphql';
 import type { OrgRepo, ProjectMetadata, RepositoryTarget } from './config';
 import { installAndLoadExtensions } from './duckdb-extensions';
-import { 
-    normalizeGetRepoDataArtifacts, 
-    getNormalizationStats as getArtifactsStats 
+import {
+    normalizeGetRepoDataArtifacts,
+    getNormalizationStats as getArtifactsStats
 } from './normalizers/GetRepoDataArtifactsNormalizer';
-import { 
-    normalizeGetRepoDataExtendedInfo, 
-    getNormalizationStats as getExtendedStats 
+import {
+    normalizeGetRepoDataExtendedInfo,
+    getNormalizationStats as getExtendedStats
 } from './normalizers/GetRepoDataExtendedInfoNormalizer';
+import {
+    parseDotProject,
+    mergeDotProjectResults,
+    getDotProjectStats,
+    type DotProjectNormalized,
+} from './normalizers/DotProjectNormalizer';
+import type { GetDotProjectDataResponse } from './api';
 
 /**
  * Write artifacts to database and Parquet files
@@ -667,6 +674,169 @@ export async function writeOrgRepoArtifacts(
             con.closeSync();
         } catch (error) {
             console.warn('Warning: Could not properly close database connection:', error);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// .project data writer
+// ---------------------------------------------------------------------------
+
+/**
+ * DuckDB table schemas for empty .project tables.
+ * Mirrors the DotProjectNormalizer record shapes exactly.
+ */
+const DOT_PROJECT_TABLE_SCHEMAS = {
+    dot_project: `
+        org TEXT NOT NULL,
+        source_url TEXT NOT NULL,
+        schema_version TEXT,
+        slug TEXT,
+        name TEXT,
+        description TEXT,
+        type TEXT,
+        project_lead TEXT,
+        repository_count INTEGER,
+        website TEXT,
+        current_maturity TEXT,
+        current_maturity_date TEXT,
+        audit_count INTEGER,
+        security_policy_path TEXT,
+        security_threat_model_path TEXT,
+        security_contact_email TEXT,
+        security_advisory_url TEXT,
+        landscape_category TEXT,
+        landscape_subcategory TEXT,
+        package_managers_json TEXT,
+        fetched_at TIMESTAMP
+    `,
+    dot_project_repositories: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        repo_url TEXT NOT NULL,
+        repo_owner TEXT,
+        repo_name TEXT
+    `,
+    dot_project_maturity_log: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        phase TEXT,
+        date TEXT,
+        issue TEXT
+    `,
+    dot_project_audits: `
+        org TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        date TEXT,
+        type TEXT,
+        url TEXT
+    `,
+} as const;
+
+/**
+ * Processes GetDotProjectData GraphQL responses and writes four .project tables
+ * to an existing DuckDB database.  Follows the same temp-JSON + read_json()
+ * pattern used throughout ArtifactWriter.
+ *
+ * Tables written:
+ *   dot_project              — one row per org that has a .project repo
+ *   dot_project_repositories — one row per URL in repositories[]
+ *   dot_project_maturity_log — one row per maturity_log entry
+ *   dot_project_audits       — one row per audits[] entry
+ *
+ * Called from neo.ts after the main scan is complete (analogous to writeOrgRepoArtifacts).
+ *
+ * @param dotProjectResponses - Raw GraphQL responses from fetchDotProjectData (non-null only)
+ * @param outputDir           - Timestamped run directory that already contains database.db
+ */
+export async function writeDotProjectArtifacts(
+    dotProjectResponses: Array<{ org: string; data: GetDotProjectDataResponse }>,
+    outputDir: string
+): Promise<void> {
+    const dbPath = path.join(outputDir, 'database.db');
+    const db = await DuckDBInstance.create(dbPath);
+    const con = await db.connect();
+
+    try {
+        await installAndLoadExtensions(con);
+
+        console.log(chalk.cyan('\n📋 Processing .project data...'));
+
+        // Parse and normalize all responses
+        const parseResults = dotProjectResponses.map(({ org, data }) => {
+            const repo = data.repository;
+            if (!repo) return null;
+
+            const projectYamlBlob = repo.projectYaml;
+            if (
+                !projectYamlBlob ||
+                projectYamlBlob.__typename !== 'Blob' ||
+                !projectYamlBlob.text
+            ) {
+                // Repo exists but no project.yaml — unusual, skip
+                console.log(chalk.gray(`  ○ ${org}/.project: repo exists but no project.yaml`));
+                return null;
+            }
+
+            const sourceUrl = `https://github.com/${repo.nameWithOwner}/blob/HEAD/project.yaml`;
+            const result = parseDotProject(org, projectYamlBlob.text, sourceUrl);
+
+            if (!result) {
+                console.log(chalk.yellow(`  ⚠ ${org}/.project: project.yaml parse error`));
+                return null;
+            }
+
+            const maturity = result.dot_project[0]?.current_maturity ?? 'unknown';
+            console.log(chalk.green(`  ✓ ${org}/.project: ${maturity} (${result.dot_project_repositories.length} repos)`));
+            return result;
+        });
+
+        const normalized: DotProjectNormalized = mergeDotProjectResults(parseResults);
+        console.log(chalk.gray('\n' + getDotProjectStats(normalized)));
+
+        // Helper: write one table using temp-JSON + read_json() (or explicit schema if empty)
+        const writeTable = async (
+            tableName: keyof typeof DOT_PROJECT_TABLE_SCHEMAS,
+            data: unknown[]
+        ) => {
+            if (data.length > 0) {
+                const tempPath = path.join(outputDir, `temp_${tableName}.json`);
+                fs.writeFileSync(tempPath, JSON.stringify(data));
+                await con.run(`
+                    CREATE TABLE ${tableName} AS
+                    SELECT * FROM read_json('${tempPath}', format='array', auto_detect=true, union_by_name=true)
+                `);
+                fs.unlinkSync(tempPath);
+            } else {
+                await con.run(`CREATE TABLE ${tableName} (${DOT_PROJECT_TABLE_SCHEMAS[tableName]})`);
+            }
+            console.log(`  ✅ Created table: ${tableName} (${data.length} rows)`);
+        };
+
+        await writeTable('dot_project', normalized.dot_project);
+        await writeTable('dot_project_repositories', normalized.dot_project_repositories);
+        await writeTable('dot_project_maturity_log', normalized.dot_project_maturity_log);
+        await writeTable('dot_project_audits', normalized.dot_project_audits);
+
+        // Export new tables to Parquet (appends alongside existing parquet/ files)
+        const parquetDir = path.join(outputDir, 'parquet');
+        fs.mkdirSync(parquetDir, { recursive: true });
+
+        for (const tableName of Object.keys(DOT_PROJECT_TABLE_SCHEMAS) as Array<keyof typeof DOT_PROJECT_TABLE_SCHEMAS>) {
+            const parquetPath = path.join(parquetDir, `${tableName}.parquet`);
+            await con.run(`
+                COPY ${tableName} TO '${parquetPath}'
+                (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 100000)
+            `);
+        }
+        console.log(chalk.green('  ✓ Exported .project tables to Parquet'));
+
+        await con.run('CHECKPOINT');
+    } finally {
+        try {
+            con.closeSync();
+        } catch (error) {
+            console.warn('Warning: Could not properly close .project database connection:', error);
         }
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,6 +25,62 @@ import {
   GetOrgReposQuery,
 } from './generated/graphql';
 
+// ---------------------------------------------------------------------------
+// GetDotProjectData — inline query (avoids codegen dependency for new query)
+//
+// Fetches project.yaml (and maintainers.yaml) from the <org>/.project repo.
+// These are the canonical CNCF .project metadata files per the schema at:
+// ~/gh/f/cncf/automation/utilities/dot-project/SCHEMA.md
+//
+// Run `npm run codegen` to generate typed Document/Query for this if preferred.
+// ---------------------------------------------------------------------------
+const GET_DOT_PROJECT_DATA_QUERY = `
+  query GetDotProjectData($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      __typename
+      id
+      nameWithOwner
+      projectYaml: object(expression: "HEAD:project.yaml") {
+        ... on Blob {
+          __typename
+          id
+          text
+        }
+      }
+      maintainersYaml: object(expression: "HEAD:maintainers.yaml") {
+        ... on Blob {
+          __typename
+          id
+          text
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Shape of the GetDotProjectData response.
+ * Hand-typed here because we bypass the codegen for this query.
+ * Run `npm run codegen` to generate a proper typed document if desired.
+ */
+export interface GetDotProjectDataResponse {
+  repository: {
+    __typename: string;
+    id: string;
+    nameWithOwner: string;
+    projectYaml: {
+      __typename: string;
+      id: string;
+      text: string | null;
+    } | null;
+    maintainersYaml: {
+      __typename: string;
+      id: string;
+      text: string | null;
+    } | null;
+  } | null;
+}
+
 /**
  * Creates and configures a GraphQLClient for the GitHub API.
  * @param token - The GitHub Personal Access Token.
@@ -281,4 +337,81 @@ export async function fetchOrgRepos(
   }
 
   return { org, repos: allRepos, totalCount: allRepos.length };
+}
+
+// ---------------------------------------------------------------------------
+// .project data fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches project.yaml (and maintainers.yaml) from the <org>/.project repository.
+ *
+ * The .project repo is the canonical CNCF project metadata store. It lives at
+ * github.com/<org>/.project and contains project.yaml at the repo root.
+ * Many CNCF orgs don't have a .project repo yet — absent repos return null gracefully.
+ *
+ * Implementation note: uses the same GraphQL blob-fetch mechanism as
+ * GetRepoDataExtendedInfo (object(expression: "HEAD:...") { ... on Blob { text } }).
+ * The query is inlined rather than generated to avoid a codegen round-trip;
+ * run `npm run codegen` if you want a typed document node for this query.
+ *
+ * @param client  - GraphQL client (requires auth token)
+ * @param org     - GitHub organization login (e.g. "argoproj")
+ * @param verbose - Enable verbose logging
+ * @returns Parsed response, or null if the repo doesn't exist / fetch fails
+ */
+export async function fetchDotProjectData(
+  client: GraphQLClient,
+  org: string,
+  verbose: boolean
+): Promise<GetDotProjectDataResponse | null> {
+  const identifier = `${org}/.project`;
+
+  if (verbose) {
+    console.log(chalk.gray(`[API] Fetching .project for ${identifier}...`));
+  }
+
+  try {
+    const data = await client.request<GetDotProjectDataResponse>(
+      GET_DOT_PROJECT_DATA_QUERY,
+      { owner: org, name: '.project' }
+    );
+
+    if (data.repository === null) {
+      if (verbose) {
+        console.log(chalk.gray(`[API] ${identifier}: no .project repo (expected for most orgs)`));
+      }
+      return null;
+    }
+
+    if (verbose) {
+      const hasYaml = data.repository.projectYaml !== null;
+      console.log(chalk.green(`[API] ${identifier}: found (project.yaml: ${hasYaml ? 'yes' : 'no'})`));
+    }
+
+    return data;
+  } catch (error: unknown) {
+    // A NOT_FOUND error (repo doesn't exist) is expected and non-fatal.
+    // Any other error is logged but also returns null to keep the scan running.
+    if (error instanceof ClientError) {
+      const errors = error.response.errors ?? [];
+      const isNotFound = errors.some(
+        // GraphQLError has extensions.code or a raw `type` field depending on GitHub's error shape
+        (e: { type?: string; extensions?: { code?: string } }) =>
+          e.type === 'NOT_FOUND' || e.extensions?.code === 'NOT_FOUND'
+      );
+      if (isNotFound) {
+        if (verbose) {
+          console.log(chalk.gray(`[API] ${identifier}: NOT_FOUND (no .project repo)`));
+        }
+        return null;
+      }
+
+      // Log non-404 errors at warn level (don't fail the scan)
+      console.warn(chalk.yellow(`[API] ${identifier}: GraphQL error`), JSON.stringify(errors));
+    } else if (error instanceof Error) {
+      console.warn(chalk.yellow(`[API] ${identifier}: ${error.message}`));
+    }
+    return null;
+  }
 }

--- a/src/graphql/GetDotProjectData.graphql
+++ b/src/graphql/GetDotProjectData.graphql
@@ -1,0 +1,21 @@
+query GetDotProjectData($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    __typename
+    id
+    nameWithOwner
+    projectYaml: object(expression: "HEAD:project.yaml") {
+      ... on Blob {
+        __typename
+        id
+        text
+      }
+    }
+    maintainersYaml: object(expression: "HEAD:maintainers.yaml") {
+      ... on Blob {
+        __typename
+        id
+        text
+      }
+    }
+  }
+}

--- a/src/neo.ts
+++ b/src/neo.ts
@@ -6,9 +6,9 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { createApiClient, fetchRepositoryArtifacts, fetchRepositoryExtendedInfo, fetchOrgRepos } from './api';
+import { createApiClient, fetchRepositoryArtifacts, fetchRepositoryExtendedInfo, fetchOrgRepos, fetchDotProjectData } from './api';
 import { appendRawResponse } from './rawResponseWriter';
-import { writeArtifacts, writeOrgRepoArtifacts } from './ArtifactWriter';
+import { writeArtifacts, writeOrgRepoArtifacts, writeDotProjectArtifacts } from './ArtifactWriter';
 import type { RepositoryTarget, ProjectMetadata } from './config';
 import { normalizeGetOrgRepos, getOrgReposNormalizationStats } from './normalizers/GetOrgReposNormalizer';
 import { SecurityAnalyzer } from './SecurityAnalyzer';
@@ -83,6 +83,7 @@ async function main() {
     .option('--analyze', 'Run security analysis after data collection', false)
     .option('--persist-files', 'Persist downloaded files (SECURITY.md, security-insights.yml) to disk', true)
     .option('--scan-orgs', 'Scan all GitHub orgs found in input data for repo discovery', false)
+    .option('--dot-project', 'Fetch .project metadata (project.yaml) for each org via GraphQL and write to DuckDB', false)
     .option('-v, --verbose', 'Verbose output', false)
     .parse(process.argv);
 
@@ -97,6 +98,7 @@ async function main() {
     analyze: runAnalysis,
     persistFiles,
     scanOrgs,
+    dotProject: fetchDotProject,
     verbose
   } = options;
 
@@ -245,6 +247,55 @@ async function main() {
     }
   } else {
     console.log(chalk.yellow('\n⚠  No data collected for any query, skipping database creation'));
+  }
+
+  // .project metadata: fetch project.yaml from <org>/.project for each unique org
+  if (fetchDotProject && allResponses.length > 0) {
+    console.log(chalk.gray('\n' + '─'.repeat(50)));
+    console.log(chalk.bold.cyan('\n📋 Fetching .project metadata...\n'));
+
+    // Collect unique orgs from the scanned repos
+    const dotProjectOrgSet = new Set<string>();
+    for (const item of normalizedInput) {
+      dotProjectOrgSet.add(item.repo.owner);
+    }
+    const uniqueOrgs = Array.from(dotProjectOrgSet);
+    console.log(chalk.cyan(`  Unique orgs to probe: ${uniqueOrgs.length}`));
+
+    // Fetch <org>/.project for each unique org (sequential to be polite)
+    const dotProjectResults: Array<{ org: string; data: import('./api').GetDotProjectDataResponse }> = [];
+    let dotProjectFound = 0;
+    let dotProjectMissing = 0;
+
+    for (const org of uniqueOrgs) {
+      const data = await fetchDotProjectData(client, org, verbose);
+      if (data && data.repository !== null) {
+        dotProjectResults.push({ org, data });
+        dotProjectFound++;
+        if (!verbose) {
+          console.log(chalk.green(`  ✓ ${org}/.project`));
+        }
+      } else {
+        dotProjectMissing++;
+        if (verbose) {
+          console.log(chalk.gray(`  ○ ${org}/.project: not found (skipped)`));
+        }
+      }
+    }
+
+    console.log(chalk.gray(`\n  Found: ${dotProjectFound}, Missing/skipped: ${dotProjectMissing}`));
+
+    if (dotProjectResults.length > 0) {
+      try {
+        await writeDotProjectArtifacts(dotProjectResults, timestampedDir);
+        console.log(chalk.green('  ✓ .project tables written to database'));
+      } catch (error) {
+        console.error(chalk.red('\n❌ .project write failed:'), error);
+        throw error;
+      }
+    } else {
+      console.log(chalk.yellow('  ⚠ No .project repos found for any org in this scan'));
+    }
   }
 
   // Org-level scanning: discover all repos across orgs present in the input data

--- a/src/normalizers/DotProjectNormalizer.ts
+++ b/src/normalizers/DotProjectNormalizer.ts
@@ -1,0 +1,316 @@
+/**
+ * DotProjectNormalizer.ts
+ *
+ * Parses fetched project.yaml text (from the <org>/.project repository) and
+ * normalizes it into flat relational records suitable for DuckDB insert.
+ *
+ * Schema source: ~/gh/f/cncf/automation/utilities/dot-project/SCHEMA.md
+ *
+ * Tables produced:
+ *   dot_project              — one row per project org (top-level fields)
+ *   dot_project_repositories — one row per URL in repositories[]
+ *   dot_project_maturity_log — one row per maturity_log entry
+ *   dot_project_audits       — one row per audits[] entry
+ */
+
+import * as yaml from 'yaml';
+
+// ---------------------------------------------------------------------------
+// Raw .project YAML shape (what we care about)
+// ---------------------------------------------------------------------------
+
+export interface DotProjectYaml {
+  schema_version?: string;
+  slug?: string;
+  name?: string;
+  description?: string;
+  type?: string;
+  project_lead?: string | string[];
+  repositories?: string[];
+  website?: string;
+  maturity_log?: Array<{
+    phase?: string;
+    date?: string | Date;
+    issue?: string;
+  }>;
+  audits?: Array<{
+    date?: string | Date;
+    type?: string;
+    url?: string;
+  }>;
+  security?: {
+    policy?: { path?: string };
+    threat_model?: { path?: string };
+    contact?: {
+      email?: string;
+      advisory_url?: string;
+    };
+  };
+  package_managers?: Record<string, string | string[]>;
+  landscape?: {
+    category?: string;
+    subcategory?: string;
+  };
+  // We capture but don't deep-expand governance / legal / documentation
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Normalized record types (DuckDB row shapes)
+// ---------------------------------------------------------------------------
+
+export interface DotProjectRecord {
+  /** Synthetic primary key: the GitHub org login */
+  org: string;
+  /** Source URL: https://github.com/<org>/.project/blob/HEAD/project.yaml */
+  source_url: string;
+  schema_version: string | null;
+  slug: string | null;
+  name: string | null;
+  description: string | null;
+  type: string | null;
+  /**
+   * project_lead serialized as a comma-separated string
+   * (handles both string and string[] schema variants)
+   */
+  project_lead: string | null;
+  repository_count: number;
+  website: string | null;
+  /** Current/latest maturity phase (last entry in maturity_log) */
+  current_maturity: string | null;
+  /** Date of current/latest maturity phase transition */
+  current_maturity_date: string | null;
+  audit_count: number;
+  /** Security policy path */
+  security_policy_path: string | null;
+  /** Threat model path */
+  security_threat_model_path: string | null;
+  /** Security contact email */
+  security_contact_email: string | null;
+  /** Security advisory URL */
+  security_advisory_url: string | null;
+  /** Landscape category */
+  landscape_category: string | null;
+  /** Landscape subcategory */
+  landscape_subcategory: string | null;
+  /** package_managers serialized as JSON string */
+  package_managers_json: string | null;
+  fetched_at: string;
+}
+
+export interface DotProjectRepository {
+  /** FK → dot_project.org */
+  org: string;
+  /** Ordinal position in repositories[] (0-indexed) */
+  position: number;
+  /** Raw URL from repositories[] */
+  repo_url: string;
+  /** Parsed GitHub owner (null if not a github.com URL) */
+  repo_owner: string | null;
+  /** Parsed GitHub repo name (null if not a github.com URL) */
+  repo_name: string | null;
+}
+
+export interface DotProjectMaturityEntry {
+  /** FK → dot_project.org */
+  org: string;
+  /** Ordinal position in maturity_log[] (0-indexed, chronological) */
+  position: number;
+  phase: string | null;
+  date: string | null;
+  issue: string | null;
+}
+
+export interface DotProjectAudit {
+  /** FK → dot_project.org */
+  org: string;
+  /** Ordinal position in audits[] (0-indexed) */
+  position: number;
+  date: string | null;
+  type: string | null;
+  url: string | null;
+}
+
+export interface DotProjectNormalized {
+  dot_project: DotProjectRecord[];
+  dot_project_repositories: DotProjectRepository[];
+  dot_project_maturity_log: DotProjectMaturityEntry[];
+  dot_project_audits: DotProjectAudit[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a github.com URL and return { owner, name } or null.
+ * Handles https://github.com/org/repo and https://github.com/org/repo.git
+ */
+function parseGithubUrl(url: string): { owner: string; name: string } | null {
+  const match = url.match(/github\.com\/([^/]+)\/([^/#? ]+)/);
+  if (!match) return null;
+  return {
+    owner: match[1],
+    name: match[2].replace(/\.git$/, ''),
+  };
+}
+
+/** Coerce a date value (string or Date) to ISO string or null */
+function toIsoString(val: string | Date | null | undefined): string | null {
+  if (!val) return null;
+  if (val instanceof Date) return val.toISOString();
+  return String(val);
+}
+
+/** Coerce project_lead (string | string[]) to a comma-separated string */
+function serializeProjectLead(lead: string | string[] | null | undefined): string | null {
+  if (!lead) return null;
+  if (Array.isArray(lead)) {
+    const flat = lead.map(s => String(s).trim()).filter(Boolean);
+    return flat.length > 0 ? flat.join(', ') : null;
+  }
+  const s = String(lead).trim();
+  return s || null;
+}
+
+// ---------------------------------------------------------------------------
+// Core parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single project.yaml text blob fetched from <org>/.project
+ * and return normalized records.
+ *
+ * @param org - GitHub org login (used as FK / PK)
+ * @param projectYamlText - Raw YAML text of project.yaml
+ * @param sourceUrl - Canonical source URL for provenance
+ * @returns Normalized records, or null if YAML is invalid / empty
+ */
+export function parseDotProject(
+  org: string,
+  projectYamlText: string,
+  sourceUrl: string
+): DotProjectNormalized | null {
+  let parsed: DotProjectYaml;
+  try {
+    parsed = yaml.parse(projectYamlText) as DotProjectYaml;
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const now = new Date().toISOString();
+
+  // ── maturity_log ──────────────────────────────────────────────────────────
+  const maturityLog = parsed.maturity_log ?? [];
+  const maturityEntries: DotProjectMaturityEntry[] = maturityLog.map((entry, i) => ({
+    org,
+    position: i,
+    phase: entry.phase ?? null,
+    date: toIsoString(entry.date),
+    issue: entry.issue ?? null,
+  }));
+
+  // Current maturity = last chronological entry
+  const lastMaturity = maturityLog.length > 0 ? maturityLog[maturityLog.length - 1] : null;
+
+  // ── audits ────────────────────────────────────────────────────────────────
+  const rawAudits = parsed.audits ?? [];
+  const auditEntries: DotProjectAudit[] = rawAudits.map((audit, i) => ({
+    org,
+    position: i,
+    date: toIsoString(audit.date),
+    type: audit.type ?? null,
+    url: audit.url ?? null,
+  }));
+
+  // ── repositories ──────────────────────────────────────────────────────────
+  const rawRepos = parsed.repositories ?? [];
+  const repoEntries: DotProjectRepository[] = rawRepos.map((url, i) => {
+    const gh = parseGithubUrl(url);
+    return {
+      org,
+      position: i,
+      repo_url: url,
+      repo_owner: gh?.owner ?? null,
+      repo_name: gh?.name ?? null,
+    };
+  });
+
+  // ── package_managers ──────────────────────────────────────────────────────
+  let packageManagersJson: string | null = null;
+  if (parsed.package_managers && typeof parsed.package_managers === 'object') {
+    try {
+      packageManagersJson = JSON.stringify(parsed.package_managers);
+    } catch {
+      packageManagersJson = null;
+    }
+  }
+
+  // ── top-level record ──────────────────────────────────────────────────────
+  const record: DotProjectRecord = {
+    org,
+    source_url: sourceUrl,
+    schema_version: parsed.schema_version ?? null,
+    slug: parsed.slug ?? null,
+    name: parsed.name ?? null,
+    description: parsed.description ?? null,
+    type: parsed.type ?? null,
+    project_lead: serializeProjectLead(parsed.project_lead),
+    repository_count: rawRepos.length,
+    website: parsed.website ?? null,
+    current_maturity: lastMaturity?.phase ?? null,
+    current_maturity_date: toIsoString(lastMaturity?.date),
+    audit_count: rawAudits.length,
+    security_policy_path: parsed.security?.policy?.path ?? null,
+    security_threat_model_path: parsed.security?.threat_model?.path ?? null,
+    security_contact_email: parsed.security?.contact?.email ?? null,
+    security_advisory_url: parsed.security?.contact?.advisory_url ?? null,
+    landscape_category: parsed.landscape?.category ?? null,
+    landscape_subcategory: parsed.landscape?.subcategory ?? null,
+    package_managers_json: packageManagersJson,
+    fetched_at: now,
+  };
+
+  return {
+    dot_project: [record],
+    dot_project_repositories: repoEntries,
+    dot_project_maturity_log: maturityEntries,
+    dot_project_audits: auditEntries,
+  };
+}
+
+/**
+ * Merge multiple parseDotProject results into a single DotProjectNormalized.
+ * Skips any null results (parse errors / missing repos).
+ */
+export function mergeDotProjectResults(
+  results: (DotProjectNormalized | null)[]
+): DotProjectNormalized {
+  const merged: DotProjectNormalized = {
+    dot_project: [],
+    dot_project_repositories: [],
+    dot_project_maturity_log: [],
+    dot_project_audits: [],
+  };
+
+  for (const r of results) {
+    if (!r) continue;
+    merged.dot_project.push(...r.dot_project);
+    merged.dot_project_repositories.push(...r.dot_project_repositories);
+    merged.dot_project_maturity_log.push(...r.dot_project_maturity_log);
+    merged.dot_project_audits.push(...r.dot_project_audits);
+  }
+
+  return merged;
+}
+
+export function getDotProjectStats(normalized: DotProjectNormalized): string {
+  return [
+    `Normalized ${normalized.dot_project.length} .project records`,
+    `  ${normalized.dot_project_repositories.length} repositories`,
+    `  ${normalized.dot_project_maturity_log.length} maturity_log entries`,
+    `  ${normalized.dot_project_audits.length} audits`,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

- Adds `docs/PRIMER.md`: a durable internal engineering primer that committed project knowledge across the full pipeline.
- Covers architecture (Mermaid diagram), all pipeline stages, complete data model (every `base_*`, `dot_project*`, `agg_*` table), utility script inventory, repo-list-refresh recipe with staleness verdict, and a documentation audit table.

## What's in the PRIMER

**Architecture:** End-to-end Mermaid flowchart from input sources through collection, DuckDB storage, SQL analysis, LadybugDB graph, and reporting.

**Pipeline stages:** Each of the 5 stages documented with CLI flags, execution flow, and what gets written where.

**Data model:** Every table in every layer — raw_*, base_*, dot_project*, agg_* — with columns, types, FKs, and the normalizer/SQL model that produces them.

**Utility scripts:** Full inventory of `scripts/` including which are live, legacy, and dead. Includes `fetch-cncf-landscape-old.ts` (safe to delete) and `wget-clomonitor-data.sh` (not wired into main pipeline).

**Repo-list refresh recipe:**
- `npm run build:repos` is the canonical command (landscape `full.json` + `.project` enrichment)
- `input/cncf-full-landscape.json` is ~5.5 months stale (last updated 2026-02-02, commit `1011f44`)
- Dead endpoint note: `items.json` returns HTML — use `full.json` only
- `input/cncf-expanded-repo-list.json` is not committed (generated locally)

**Doc audit:** Keep/prune/merge table for every `.md` in the repo. Three pruning candidates identified: `docs/project-status-2026-04-27.md`, `docs/superpowers/plans/2026-03-30-parallel-workstreams.md`, `scripts/fetch-cncf-landscape-old.ts`.

## Test plan

- [ ] Read `docs/PRIMER.md` and verify the architecture diagram renders in GitHub Markdown
- [ ] Run `npm run build:repos -- --dry-run` and confirm the output matches the recipe in §4
- [ ] Confirm no source files were modified (PRIMER.md only)